### PR TITLE
turn the test infomation to github.com/net from golang.org/x/

### DIFF
--- a/websocket/exampledial_test.go
+++ b/websocket/exampledial_test.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"log"
 
-	"golang.org/x/net/websocket"
+	"github.com/golang/net/websocket"
 )
 
 // This example demonstrates a trivial client.

--- a/websocket/examplehandler_test.go
+++ b/websocket/examplehandler_test.go
@@ -8,7 +8,7 @@ import (
 	"io"
 	"net/http"
 
-	"golang.org/x/net/websocket"
+	"github.com/golang/net/websocket"
 )
 
 // Echo the data received on the WebSocket.

--- a/websocket/websocket.go
+++ b/websocket/websocket.go
@@ -4,7 +4,7 @@
 
 // Package websocket implements a client and server for the WebSocket protocol
 // as specified in RFC 6455.
-package websocket // import "golang.org/x/net/websocket"
+package websocket // import "github.com/golang/net/websocket"
 
 import (
 	"bufio"


### PR DESCRIPTION
`go get` will failed 

```
$ go get github.com/golang/net
can't load package: package github.com/golang/net: no buildable Go source files
in E:\Documents\go\src\github.com\golang\net
```