### PR TITLE
Correct missing brace in IPv6 documentation.

### DIFF
--- a/ipv6/doc.go
+++ b/ipv6/doc.go
@@ -114,7 +114,7 @@
 //			// error handling
 //		}
 //		if rcm.Dst.IsMulticast() {
-//			if rcm.Dst.Equal(group)
+//			if rcm.Dst.Equal(group) {
 //				// joined group, do something
 //			} else {
 //				// unknown group, discard


### PR DESCRIPTION
The example for multicast in the `ipv6` package is missing an opening brace and anyone copying-and-pasting the example will not be able to run it as-is.