### PR TITLE
We should set push to disabled when browsers notify us of such things.

### DIFF
--- a/http2/server.go
+++ b/http2/server.go
@@ -1236,6 +1236,20 @@ func (sc *serverConn) processResetStream(f *RSTStreamFrame) error {
 		// (Section 5.4.1) of type PROTOCOL_ERROR.
 		return ConnectionError(ErrCodeProtocol)
 	}
+
+	switch f.ErrCode {
+	case ErrCodeRefusedStream:
+		if sc.pushEnabled {
+			sc.pushEnabled = false
+			sc.vlogf("http2: push disabled due to client RST frame with code REFUSED_STREAM")
+		}
+	case ErrCodeProtocol:
+		if sc.pushEnabled {
+			sc.pushEnabled = false
+			sc.vlogf("http2: push disabled due to client RST frame with code PROTOCOL_ERROR")
+		}
+	}
+
 	if st != nil {
 		st.gotReset = true
 		st.cancelCtx()


### PR DESCRIPTION
In order for Safari and Firefox to work with pushed resources correctly, we found that we need to honor these errors once they come in.

This makes Safari and Firefox work for us without issues. Otherwise Safari works "sometimes" while  Firefox only works on the first connection.