### PR TITLE
# golang.org/x/net/ipv6;# golang.org/x/net/ipv4

### DIFF
--- a/http2/transport_test.go
+++ b/http2/transport_test.go
@@ -1660,3 +1660,20 @@ func TestTransportRejectsConnHeaders(t *testing.T) {
 		}
 	}
 }
+
+// Tests that gzipReader doesn't crash on a second Read call following
+// the first Read call's gzip.NewReader returning an error.
+func TestGzipReader_DoubleReadCrash(t *testing.T) {
+	gz := &gzipReader{
+		body: ioutil.NopCloser(strings.NewReader("0123456789")),
+	}
+	var buf [1]byte
+	n, err1 := gz.Read(buf[:])
+	if n != 0 || !strings.Contains(fmt.Sprint(err1), "invalid header") {
+		t.Fatalf("Read = %v, %v; want 0, invalid header", n, err1)
+	}
+	n, err2 := gz.Read(buf[:])
+	if n != 0 || err2 != err1 {
+		t.Fatalf("second Read = %v, %v; want 0, %v", n, err2, err1)
+	}
+}


### PR DESCRIPTION
# golang.org/x/net/ipv6
../../../golang.org/x/net/ipv6/zsys_linux_arm64.go:7: sysIPV6_ADDRFORM redeclared in this block
        previous declaration at ../../../golang.org/x/net/ipv6/zsys_linux_amd64.go:7
../../../golang.org/x/net/ipv6/zsys_linux_arm64.go:8: sysIPV6_2292PKTINFO redeclared in this block
        previous declaration at ../../../golang.org/x/net/ipv6/zsys_linux_amd64.go:8
../../../golang.org/x/net/ipv6/zsys_linux_arm64.go:9: sysIPV6_2292HOPOPTS redeclared in this block
        previous declaration at ../../../golang.org/x/net/ipv6/zsys_linux_amd64.go:9
../../../golang.org/x/net/ipv6/zsys_linux_arm64.go:10: sysIPV6_2292DSTOPTS redeclared in this block
        previous declaration at ../../../golang.org/x/net/ipv6/zsys_linux_amd64.go:10
../../../golang.org/x/net/ipv6/zsys_linux_arm64.go:11: sysIPV6_2292RTHDR redeclared in this block
        previous declaration at ../../../golang.org/x/net/ipv6/zsys_linux_amd64.go:11
../../../golang.org/x/net/ipv6/zsys_linux_arm64.go:12: sysIPV6_2292PKTOPTIONS redeclared in this block
        previous declaration at ../../../golang.org/x/net/ipv6/zsys_linux_amd64.go:12
../../../golang.org/x/net/ipv6/zsys_linux_arm64.go:13: sysIPV6_CHECKSUM redeclared in this block
        previous declaration at ../../../golang.org/x/net/ipv6/zsys_linux_amd64.go:13
../../../golang.org/x/net/ipv6/zsys_linux_arm64.go:14: sysIPV6_2292HOPLIMIT redeclared in this block
        previous declaration at ../../../golang.org/x/net/ipv6/zsys_linux_amd64.go:14
../../../golang.org/x/net/ipv6/zsys_linux_arm64.go:15: sysIPV6_NEXTHOP redeclared in this block
        previous declaration at ../../../golang.org/x/net/ipv6/zsys_linux_amd64.go:15
../../../golang.org/x/net/ipv6/zsys_linux_arm64.go:16: sysIPV6_FLOWINFO redeclared in this block
        previous declaration at ../../../golang.org/x/net/ipv6/zsys_linux_amd64.go:16
../../../golang.org/x/net/ipv6/zsys_linux_arm64.go:16: too many errors
# golang.org/x/net/ipv4
../../../golang.org/x/net/ipv4/zsys_linux_arm64.go:7: sysIP_TOS redeclared in this block
        previous declaration at ../../../golang.org/x/net/ipv4/zsys_linux_amd64.go:7
../../../golang.org/x/net/ipv4/zsys_linux_arm64.go:8: sysIP_TTL redeclared in this block
        previous declaration at ../../../golang.org/x/net/ipv4/zsys_linux_amd64.go:8
../../../golang.org/x/net/ipv4/zsys_linux_arm64.go:9: sysIP_HDRINCL redeclared in this block
        previous declaration at ../../../golang.org/x/net/ipv4/zsys_linux_amd64.go:9
../../../golang.org/x/net/ipv4/zsys_linux_arm64.go:10: sysIP_OPTIONS redeclared in this block
        previous declaration at ../../../golang.org/x/net/ipv4/zsys_linux_amd64.go:10
../../../golang.org/x/net/ipv4/zsys_linux_arm64.go:11: sysIP_ROUTER_ALERT redeclared in this block
        previous declaration at ../../../golang.org/x/net/ipv4/zsys_linux_amd64.go:11
../../../golang.org/x/net/ipv4/zsys_linux_arm64.go:12: sysIP_RECVOPTS redeclared in this block
        previous declaration at ../../../golang.org/x/net/ipv4/zsys_linux_amd64.go:12
../../../golang.org/x/net/ipv4/zsys_linux_arm64.go:13: sysIP_RETOPTS redeclared in this block
        previous declaration at ../../../golang.org/x/net/ipv4/zsys_linux_amd64.go:13
../../../golang.org/x/net/ipv4/zsys_linux_arm64.go:14: sysIP_PKTINFO redeclared in this block
        previous declaration at ../../../golang.org/x/net/ipv4/zsys_linux_amd64.go:14
../../../golang.org/x/net/ipv4/zsys_linux_arm64.go:15: sysIP_PKTOPTIONS redeclared in this block
        previous declaration at ../../../golang.org/x/net/ipv4/zsys_linux_amd64.go:15
../../../golang.org/x/net/ipv4/zsys_linux_arm64.go:16: sysIP_MTU_DISCOVER redeclared in this block
        previous declaration at ../../../golang.org/x/net/ipv4/zsys_linux_amd64.go:16
../../../golang.org/x/net/ipv4/zsys_linux_arm64.go:16: too many errors