### PR TITLE
Add HTTP status code to ErrBadStatus

### DIFF
--- a/websocket/hybi.go
+++ b/websocket/hybi.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"strconv"
 )
 
 const (
@@ -442,6 +443,7 @@ func hybiClientHandshake(config *Config, br *bufio.Reader, bw *bufio.Writer) (er
 		return err
 	}
 	if resp.StatusCode != 101 {
+		ErrBadStatus.ErrorString = "bad status: " + strconv.Itoa(resp.StatusCode)
 		return ErrBadStatus
 	}
 	if strings.ToLower(resp.Header.Get("Upgrade")) != "websocket" ||


### PR DESCRIPTION
When the websocket handshake fails there is no way the client can figure out what's wrong if we don't specify the HTTP response code. This change appends the HTTP status code to the error message.