### PR TITLE
xsrftoken: panic for unsafe zero length keys

### DIFF
--- a/xsrftoken/xsrf.go
+++ b/xsrftoken/xsrf.go
@@ -36,6 +36,9 @@ func Generate(key, userID, actionID string) string {
 
 // generateTokenAtTime is like Generate, but returns a token that expires 24 hours from now.
 func generateTokenAtTime(key, userID, actionID string, now time.Time) string {
+	if len(key) == 0 {
+		panic("zero length xsrf secret key")
+	}
 	// Round time up and convert to milliseconds.
 	milliTime := (now.UnixNano() + 1e6 - 1) / 1e6
 


### PR DESCRIPTION
Passing a zero length key (or secret) gives no safety against XSRF attacks. This is a relatively easy mistake to make, e.g. by passing `make([]byte, 0, 1024)` to `rand.Read` instead of `make([]byte, 1024)`, and currently fails open, silently.

This uses panic, as the API does not allow returning a structured error, and catching this programming error is not worth breaking API compatibility. Passing a zero length secret is also not an error condition that API callers would handle, so there is little value in returning a proper error.