### PR TITLE
removed init level registration of debug handlers

### DIFF
--- a/trace/trace.go
+++ b/trace/trace.go
@@ -109,7 +109,7 @@ var AuthRequest = func(req *http.Request) (any, sensitive bool) {
 	}
 }
 
-func init() {
+func RegisterDebugHandlers() {
 	// TODO(jbd): Serve Traces from /debug/traces in the future?
 	// There is no requirement for a request to be present to have traces.
 	http.HandleFunc("/debug/requests", Traces)


### PR DESCRIPTION
since the debug handlers already exposed, give developer flexibility to register his/her own endpoints.
there is no point of registering them at the initialization of package level