### PR TITLE
icmp: fix ExtendedEchoRequest extension object

### DIFF
--- a/icmp/multipart_test.go
+++ b/icmp/multipart_test.go
@@ -232,11 +232,6 @@ func TestMarshalAndParseMultipartMessage(t *testing.T) {
 							Type:  2,
 							Index: 911,
 						},
-						&icmp.InterfaceIdent{
-							Class: 3,
-							Type:  1,
-							Name:  "en101",
-						},
 					},
 				},
 			},


### PR DESCRIPTION
RFC8335 [1] Sec 2: "When applied to the ICMP
Extended Echo Request message, the ICMP Extension Structure MUST
contain exactly one instance of the Interface Identification Object."

The InterfaceIdent by name object seems to be a copy/paste issue.

[1]: https://www.rfc-editor.org/rfc/rfc8335.txt