### PR TITLE
fix the error that the final Read of the frame payload bytes discarded

### DIFF
--- a/websocket/websocket.go
+++ b/websocket/websocket.go
@@ -212,7 +212,6 @@ again:
 			io.Copy(ioutil.Discard, trailer)
 		}
 		ws.frameReader = nil
-		goto again
 	}
 	return n, err
 }


### PR DESCRIPTION
This is a little snippet displaying the error caused by this line.
```
package main

import (
	"bufio"
	"flag"
	"fmt"
	"os"

	"golang.org/x/net/websocket"
)

func main() {
	var origin string
	var url string
	flag.StringVar(&origin, "origin", "", "websocket origin")
	flag.StringVar(&url, "url", "", "websocket remote url")
	flag.Parse()

	ws, err := websocket.Dial(url, "", origin)
	if err != nil {
		panic(err)
		return
	}

	buffer := make([]byte, 100)
	bScanner := bufio.NewScanner(os.Stdin)
	fmt.Print("> ")
	for bScanner.Scan() {
		line := bScanner.Text()
		ws.Write([]byte(line + "\r\n"))

		num, err := ws.Read(buffer)
		if err != nil {
			ws.Close()
			return
		}
		fmt.Println("total:", ws.Len(), "read:", num)
		buffer = make([]byte, ws.Len())

		remained := ws.Len() - num
		for {
			fmt.Println("remained:", remained)
			num, err = ws.Read(buffer)
			if err != nil {
				ws.Close()
				return
			}
			remained -= num
			fmt.Println("next read:", num)
		}
		// for next command
		fmt.Println()
		fmt.Print("> ")
	}
}
```
When the buffer size of the ws.Read is not enough, we call this Read multiple times, but the last call of this ws.Read is led into the block `again`, which is wrong under this case.