### PR TITLE
allows brackets in cookie name

### DIFF
--- a/http/httpguts/httplex.go
+++ b/http/httpguts/httplex.go
@@ -14,6 +14,8 @@ import (
 
 var isTokenTable = [127]bool{
 	'!':  true,
+	'[':  true,
+	']':  true,
 	'#':  true,
 	'$':  true,
 	'%':  true,

--- a/http/httpguts/httplex_test.go
+++ b/http/httpguts/httplex_test.go
@@ -14,7 +14,7 @@ func isCtl(c rune) bool { return c <= 31 || c == 127 }
 
 func isSeparator(c rune) bool {
 	switch c {
-	case '(', ')', '<', '>', '@', ',', ';', ':', '\\', '"', '/', '[', ']', '?', '=', '{', '}', ' ', '\t':
+	case '(', ')', '<', '>', '@', ',', ';', ':', '\\', '"', '/', '?', '=', '{', '}', ' ', '\t':
 		return true
 	}
 	return false


### PR DESCRIPTION
In Javascript, it's common to use array-like keys: `foo[bar][foobar]=some_value`.
However, it's impossible to retrieve the value

```
_, err := request.Cookie("foo[bar][foobar]")
```
Due to lack of the brackets, it's imposible to retrive the value this way. The only way is parsing the cookie header by own.

```
go version go1.11.5 darwin/amd64
```
My os: macOS Mojave 10.14.3 