### PR TITLE
publicsuffix: add HasListedSuffix func

### DIFF
--- a/publicsuffix/list.go
+++ b/publicsuffix/list.go
@@ -181,8 +181,9 @@ func EffectiveTLDPlusOne(domain string) (string, error) {
 	return domain[1+strings.LastIndex(domain[:i], "."):], nil
 }
 
-// HasListedSuffix returns true iff the suffix exists on the public suffix list,
-// i.e., is a known public or private, managed TLD.
+// HasListedSuffix returns true if the parameter domain's suffix exists on the
+// public suffix list, i.e., is a known public or private, managed eTLD. If
+// true, the domain's eTLD + 1 could be registered.
 func HasListedSuffix(domain string) bool {
 	domain, suffix, _ := search(domain)
 	if suffix == len(domain) {

--- a/publicsuffix/list_test.go
+++ b/publicsuffix/list_test.go
@@ -499,3 +499,29 @@ func TestEffectiveTLDPlusOne(t *testing.T) {
 		}
 	}
 }
+
+func TestHasListedSuffix(t *testing.T) {
+	var hasListedSuffixTestCases = []struct {
+		domain string
+		want   bool
+	}{
+		{"foo.com", true},
+		{"test", false},
+		{"com", true},
+		{"foo.test", false}, // Reserved TLDs see https://tools.ietf.org/html/rfc2606#page-2
+		{"foo.example", false},
+		{"foo.invalid", false},
+		{"foo.localhost", false},
+		{"example", false},
+		{"invalid", false},
+		{"localhost", false},
+		{"foo.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", false}, // too long, can never be valid TLD
+	}
+
+	for _, tc := range hasListedSuffixTestCases {
+		got := HasListedSuffix(tc.domain)
+		if got != tc.want {
+			t.Errorf("%q: got %v, want %v", tc.domain, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
The existing package does not contain a function to check whether a domain's suffix
exists on the PSL because its suffix defaults to "*" as a rule if none of the other rules
match.

This adds func HasListedSuffix(domain string) which reports whether the domain's
suffix exists on the list.

Fixes golang/go#31027
