### PR TITLE
Replaced link in comment for gzip/deflate with valid one

### DIFF
--- a/http2/transport.go
+++ b/http2/transport.go
@@ -992,7 +992,7 @@ func (cc *ClientConn) roundTrip(req *http.Request) (res *http.Response, gotErrAf
 		req.Method != "HEAD" {
 		// Request gzip only, not deflate. Deflate is ambiguous and
 		// not as universally supported anyway.
-		// See: http://www.gzip.org/zlib/zlib_faq.html#faq38
+		// See: https://zlib.net/zlib_faq.html#faq39
 		//
 		// Note that we don't request this for HEAD requests,
 		// due to a bug in nginx:


### PR DESCRIPTION
Fixes #33246 . https://github.com/golang/go/issues/33246

Replaced broken link with new one.