### PR TITLE
Preventing panic when invalid network information is given

### DIFF
--- a/icmp/helper_posix.go
+++ b/icmp/helper_posix.go
@@ -68,8 +68,8 @@ func last(s string, b byte) int {
 	i := len(s)
 	for i--; i >= 0; i-- {
 		if s[i] == b {
-			break
+			return i
 		}
 	}
-	return i
+	return -1
 }

--- a/icmp/listen_posix.go
+++ b/icmp/listen_posix.go
@@ -50,6 +50,9 @@ func ListenPacket(network, address string) (*PacketConn, error) {
 		family, proto = syscall.AF_INET6, iana.ProtocolIPv6ICMP
 	default:
 		i := last(network, ':')
+		if i == -1 {
+			return nil, errInvalidNetwork
+		}
 		switch network[:i] {
 		case "ip4":
 			proto = iana.ProtocolICMP

--- a/icmp/message.go
+++ b/icmp/message.go
@@ -37,6 +37,7 @@ var (
 	errNoExtension      = errors.New("no extension")
 	errInvalidExtension = errors.New("invalid extension")
 	errNotImplemented   = errors.New("not implemented on " + runtime.GOOS + "/" + runtime.GOARCH)
+	errInvalidNetwork   = errors.New("invalid network")
 )
 
 func checksum(b []byte) uint16 {


### PR DESCRIPTION
#32933 (https://github.com/golang/go/issues/32933)

