### PR TITLE
http2: make Transport.NewClientConn respect Transport.DisableKeepAlives

### DIFF
--- a/http2/transport.go
+++ b/http2/transport.go
@@ -603,7 +603,7 @@ func (t *Transport) expectContinueTimeout() time.Duration {
 }
 
 func (t *Transport) NewClientConn(c net.Conn) (*ClientConn, error) {
-	return t.newClientConn(c, false)
+	return t.newClientConn(c, t.disableKeepAlives())
 }
 
 func (t *Transport) newClientConn(c net.Conn, singleUse bool) (*ClientConn, error) {


### PR DESCRIPTION
While in http/1.1 the `http.Transport.DisableKeepAlives` directive disallows re-usage of the connection, in http2 it's currently implemented as "close the connection as soon as possible" (when the connection is idle).

Fixes golang/go#33260
