### PR TITLE
websocket: Add nhooyr.io/websocket to the deprecation message

### DIFF
--- a/websocket/websocket.go
+++ b/websocket/websocket.go
@@ -5,11 +5,11 @@
 // Package websocket implements a client and server for the WebSocket protocol
 // as specified in RFC 6455.
 //
-// This package currently lacks some features found in an alternative
-// and more actively maintained WebSocket package:
+// This package currently lacks some features found in alternative
+// and more actively maintained WebSocket packages:
 //
 //     https://godoc.org/github.com/gorilla/websocket
-//
+//     https://godoc.org/nhooyr.io/websocket
 package websocket // import "golang.org/x/net/websocket"
 
 import (


### PR DESCRIPTION
 My library is a well maintained alternative as well and is easier to transition to thanks to the [NetConn](https://godoc.org/nhooyr.io/websocket#NetConn) wrapper.

Updates https://github.com/golang/go/issues/18152