### PR TITLE
html: fix tokenizer error

### DIFF
--- a/html/token.go
+++ b/html/token.go
@@ -347,6 +347,7 @@ loop:
 			break loop
 		}
 		if c != '/' {
+			z.raw.end--
 			continue loop
 		}
 		if z.readRawEndTag() || z.err != nil {

--- a/html/token_test.go
+++ b/html/token_test.go
@@ -258,6 +258,11 @@ var tokenTests = []tokenTest{
 		"<title><b>K&amp;R C</b></title>",
 		"<title>$&lt;b&gt;K&amp;R C&lt;/b&gt;$</title>",
 	},
+	{
+		"title with trailing '&lt;' entity",
+		"<title>foobar<</title>",
+		"<title>$foobar&lt;$</title>",
+	},
 	// DOCTYPE tests.
 	{
 		"Proper DOCTYPE",


### PR DESCRIPTION
Trailing '<' entities in the text token make the tokenizer fail
for escapable raw text elements like title and textarea

Fixes golang/go#34281