### PR TITLE
fix x/net/websocket bug when using io.Copy from remote to local

### DIFF
--- a/websocket/websocket.go
+++ b/websocket/websocket.go
@@ -212,7 +212,7 @@ again:
 			io.Copy(ioutil.Discard, trailer)
 		}
 		ws.frameReader = nil
-		goto again
+		return n, err
 	}
 	return n, err
 }


### PR DESCRIPTION
```
func Handler(ws *websocket.Conn) {
   f, err := os.OpenFile("x.txt", os.O_RDWR|os.O_CREATE, 0755)
   if err != nil {
      log.Fatal(err)
   }
   io.Copy(f, ws)
   websocket.Message.Send(ws, "done")
}
```
Using this code, "done" would never be sent to client,
this pull request fixes this bug.