### PR TITLE
route: fill correctly field

### DIFF
--- a/route/address.go
+++ b/route/address.go
@@ -46,12 +46,12 @@ func (a *LinkAddr) marshal(b []byte) (int, error) {
 	data := b[8:]
 	if nlen > 0 {
 		b[5] = byte(nlen)
-		copy(data[:nlen], a.Addr)
+		copy(data[:nlen], a.Name)
 		data = data[nlen:]
 	}
 	if alen > 0 {
 		b[6] = byte(alen)
-		copy(data[:alen], a.Name)
+		copy(data[:alen], a.Addr)
 		data = data[alen:]
 	}
 	return ll, nil


### PR DESCRIPTION
https://github.com/golang/net/blob/master/route/address.go#L37-L56

Wrong order of filling the buffer