### PR TITLE
http2: make GoAway and INTERNAL_ERROR to implement Temporary interface

### DIFF
--- a/http2/errors.go
+++ b/http2/errors.go
@@ -78,6 +78,11 @@ func (e StreamError) Error() string {
 	return fmt.Sprintf("stream error: stream ID %d; %v", e.StreamID, e.Code)
 }
 
+func (e StreamError) Temporary() bool {
+	// Internal errors
+	return e.Code == ErrCodeInternal
+}
+
 // 6.9.1 The Flow Control Window
 // "If a sender receives a WINDOW_UPDATE that causes a flow control
 // window to exceed this maximum it MUST terminate either the stream

--- a/http2/transport.go
+++ b/http2/transport.go
@@ -1692,6 +1692,11 @@ func (e GoAwayError) Error() string {
 		e.LastStreamID, e.ErrCode, e.DebugData)
 }
 
+func (e GoAwayError) Temporary() bool {
+	// GO AWAY error should be temporary and can happen when a single connection serves more than X requests or after some timeout
+	return true
+}
+
 func isEOFOrNetReadError(err error) bool {
 	if err == io.EOF {
 		return true


### PR DESCRIPTION
... returning true.

Justification from https://github.com/golang/go/issues/35286 (#35286):

1. http.http2GoAwayError (e.g. 'http2: server sent GOAWAY and closed the
connection; LastStreamID=8329, ErrCode=NO_ERROR, debug="max_age"')

This error happens typically if server decides enough requests per connection
serviced or after some timeout or graceful shutdown
(https://http2.github.io/http2-spec/#GOAWAY).

2. http.http2StreamError with INTERNAL_ERROR code (e.g. 'stream error: stream ID 309; INTERNAL_ERROR')

According to HTTP2 SPEC:
INTERNAL_ERROR (0x2): The endpoint encountered an unexpected internal error.

i.e. this error to be used similar to HTTP 500 and real-life experience clearly
demonstrates it is retryable (like HTTP 500).

Google Cloud SDK also implements retries on this error at cloud.google.com/go/storage/reader.go:
if strings.HasSuffix(err.Error(), "INTERNAL_ERROR") && strings.Contains(reflect.TypeOf(err).String(), "http2")

Signed-off-by: Kirill Korotaev <kirillx@gmail.com>