### PR TITLE
http2: add a MinConcurrentConns field to Transport for improving throughput

### DIFF
--- a/http2/transport.go
+++ b/http2/transport.go
@@ -108,6 +108,13 @@ type Transport struct {
 	// waiting for their turn.
 	StrictMaxConcurrentStreams bool
 
+	// MinConcurrentConns is the minimum number of TCP connections.
+	// ClientConnPool tries to maintain  MinConcurrentConns
+	// TCP connections at least. If 0, ClientConnPool creates a
+	// TCP connection only when needed. The default value is 0.
+	// Increase this value if you need high throughput.
+	MinConcurrentConns uint32
+
 	// t1, if non-nil, is the standard library Transport using
 	// this transport. Its settings are used (but not its
 	// RoundTrip method, etc).

--- a/http2/transport_test.go
+++ b/http2/transport_test.go
@@ -4557,3 +4557,56 @@ func TestClientConnTooIdle(t *testing.T) {
 		}
 	}
 }
+
+func TestTransportMinConcurrentConns(t *testing.T) {
+	st := newServerTester(t,
+		func(w http.ResponseWriter, r *http.Request) {
+			io.WriteString(w, "test")
+		},
+		func(s *Server) {
+			s.MaxConcurrentStreams = 100
+			s.IdleTimeout = 30 * time.Second
+		},
+		optOnlyServer,
+	)
+	defer st.Close()
+
+	req, err := http.NewRequest("GET", st.ts.URL, nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	addr := authorityAddr(req.URL.Scheme, req.URL.Host)
+
+	MinConcurrentConns := 5
+
+	tr := &Transport{
+		TLSClientConfig: tlsConfigInsecure,
+		MinConcurrentConns: uint32(MinConcurrentConns),
+	}
+	defer tr.CloseIdleConnections()
+
+	// execute a dummy request
+	for i := 0; i < 10; i++ {
+		_, err := tr.RoundTrip(req)
+		if err != nil {
+			t.Fatalf("%v", err)
+		}
+	}
+
+	// check client connection pool
+	cp, ok := tr.connPool().(*clientConnPool)
+	if !ok {
+		t.Fatalf("Conn pool is %T; want *clientConnPool", tr.connPool())
+	}
+
+	cp.mu.Lock()
+	defer cp.mu.Unlock()
+
+	conns, ok := cp.conns[addr]
+	if !ok {
+		t.Fatalf("cannot find connections for %s", addr)
+	}
+	if len(conns) != MinConcurrentConns {
+		t.Fatalf("the number of connections should be %d, but got %d", MinConcurrentConns, len(conns))
+	}
+}


### PR DESCRIPTION
I found an issue that an http2 client can't fully utilize network resources.
Please refer to https://github.com/golang/go/issues/37373.
