### PR TITLE
http2: Fix SETTINGS_HEADER_TABLE_SIZE handling in client

### DIFF
--- a/http2/transport.go
+++ b/http2/transport.go
@@ -2295,8 +2295,10 @@ func (rl *clientConnReadLoop) processSettings(f *SettingsFrame) error {
 			cc.cond.Broadcast()
 
 			cc.initialWindowSize = s.Val
+		case SettingHeaderTableSize:
+			cc.henc.SetMaxDynamicTableSizeLimit(s.Val)
 		default:
-			// TODO(bradfitz): handle more settings? SETTINGS_HEADER_TABLE_SIZE probably.
+			// TODO(bradfitz): handle more settings?
 			cc.vlogf("Unhandled Setting: %v", s)
 		}
 		return nil


### PR DESCRIPTION
According to [RFC 7540 Section 6.5.2](https://tools.ietf.org/html/rfc7540#section-6.5.2) the SETTINGS frame with parameter SETTINGS_HEADER_TABLE_SIZE allows the sender to inform the remote endpoint the maximum size of the dynamic table for HPACK. The encoder can use any size equal or less than this value. 

This is not handled properly in Go HTTP2 client when a server sends this SETTINGS frame, causing header compression failures on subsequent requests that lead to protocol errors, GOAWAY and RST_STREAM failures. This PR fixes this behavior by addressing the handling of this parameter.