### PR TITLE
http2: remove unused addConn

### DIFF
--- a/http2/client_conn_pool.go
+++ b/http2/client_conn_pool.go
@@ -200,12 +200,6 @@ func (c *addConnCall) run(t *Transport, key string, tc *tls.Conn) {
 	close(c.done)
 }
 
-func (p *clientConnPool) addConn(key string, cc *ClientConn) {
-	p.mu.Lock()
-	p.addConnLocked(key, cc)
-	p.mu.Unlock()
-}
-
 // p.mu must be held
 func (p *clientConnPool) addConnLocked(key string, cc *ClientConn) {
 	for _, v := range p.conns[key] {


### PR DESCRIPTION
`addConn` is dead code that's not used any more. 

`addConnLocked` is used when a new connection 
needs to be added to the connection pool, and the callers
always manage the lock. 