### PR TITLE
http2: export CloseIdleConnections in client connection pool

### DIFF
--- a/http2/client_conn_pool.go
+++ b/http2/client_conn_pool.go
@@ -18,16 +18,16 @@ type ClientConnPool interface {
 	MarkDead(*ClientConn)
 }
 
-// clientConnPoolIdleCloser is the interface implemented by ClientConnPool
+// ClientConnPoolIdleCloser is the interface implemented by ClientConnPool
 // implementations which can close their idle connections.
-type clientConnPoolIdleCloser interface {
+type ClientConnPoolIdleCloser interface {
 	ClientConnPool
-	closeIdleConnections()
+	CloseIdleConnections()
 }
 
 var (
-	_ clientConnPoolIdleCloser = (*clientConnPool)(nil)
-	_ clientConnPoolIdleCloser = noDialClientConnPool{}
+	_ ClientConnPoolIdleCloser = (*clientConnPool)(nil)
+	_ ClientConnPoolIdleCloser = noDialClientConnPool{}
 )
 
 // TODO: use singleflight for dialing and addConnCalls?
@@ -237,7 +237,7 @@ func (p *clientConnPool) MarkDead(cc *ClientConn) {
 	delete(p.keys, cc)
 }
 
-func (p *clientConnPool) closeIdleConnections() {
+func (p *clientConnPool) CloseIdleConnections() {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	// TODO: don't close a cc if it was just added to the pool

--- a/http2/transport.go
+++ b/http2/transport.go
@@ -474,8 +474,8 @@ func (t *Transport) RoundTripOpt(req *http.Request, opt RoundTripOpt) (*http.Res
 // connected from previous requests but are now sitting idle.
 // It does not interrupt any connections currently in use.
 func (t *Transport) CloseIdleConnections() {
-	if cp, ok := t.connPool().(clientConnPoolIdleCloser); ok {
-		cp.closeIdleConnections()
+	if cp, ok := t.connPool().(ClientConnPoolIdleCloser); ok {
+		cp.CloseIdleConnections()
 	}
 }
 


### PR DESCRIPTION
http2 transport allows stub of `ClientConnPool`, but both `clientConnPoolIdleCloser` interface and its `closeIdleConnections()` method are private. This makes the stubbed `ClientConnPool` implementation not able to implement `closeIdleConnections()`. As a result, it will be a no-op when
the transport call `transport.CloseIdleConnections()`.

Therefore, export  `CloseIdleConnections()` method is needed. Exporting `ClientConnPoolIdleCloser` interface is technically not needed, but it makes the API contract more explicit, and  allows the stubbed implementation to do something like:

```
 _ http2.ClientConnPoolIdleCloser = (*clientConnPool)(nil)
```