### PR TITLE
http2: export CloseIfIdle in ClientConn

### DIFF
--- a/http2/client_conn_pool.go
+++ b/http2/client_conn_pool.go
@@ -248,7 +248,7 @@ func (p *clientConnPool) closeIdleConnections() {
 	// break some caller's RoundTrip.
 	for _, vv := range p.conns {
 		for _, cc := range vv {
-			cc.closeIfIdle()
+			cc.CloseIfIdle()
 		}
 	}
 }

--- a/http2/transport.go
+++ b/http2/transport.go
@@ -761,14 +761,16 @@ func (cc *ClientConn) tooIdleLocked() bool {
 // onIdleTimeout is called from a time.AfterFunc goroutine. It will
 // only be called when we're idle, but because we're coming from a new
 // goroutine, there could be a new request coming in at the same time,
-// so this simply calls the synchronized closeIfIdle to shut down this
-// connection. The timer could just call closeIfIdle, but this is more
+// so this simply calls the synchronized CloseIfIdle to shut down this
+// connection. The timer could just call CloseIfIdle, but this is more
 // clear.
 func (cc *ClientConn) onIdleTimeout() {
-	cc.closeIfIdle()
+	cc.CloseIfIdle()
 }
 
-func (cc *ClientConn) closeIfIdle() {
+// CloseIfIdle closes the client connection if it's idle.
+// exported for user-specified ClientConnPool usage.
+func (cc *ClientConn) CloseIfIdle() {
 	cc.mu.Lock()
 	if len(cc.streams) > 0 {
 		cc.mu.Unlock()
@@ -1799,7 +1801,7 @@ func (rl *clientConnReadLoop) run() error {
 			return err
 		}
 		if rl.closeWhenIdle && gotReply && maybeIdle {
-			cc.closeIfIdle()
+			cc.CloseIfIdle()
 		}
 	}
 }


### PR DESCRIPTION
The default HTTP2 transport `ClientConnPool` uses `ClientConn.closeIfIdle()`. Exporting the
method so that a user-provided `ClientConnPool`  can use that as well. 
