### PR TITLE
webdav: close file before asking for Stat on file PUT

### DIFF
--- a/webdav/webdav.go
+++ b/webdav/webdav.go
@@ -269,8 +269,8 @@ func (h *Handler) handlePut(w http.ResponseWriter, r *http.Request) (status int,
 		return http.StatusNotFound, err
 	}
 	_, copyErr := io.Copy(f, r.Body)
-	fi, statErr := f.Stat()
 	closeErr := f.Close()
+	fi, statErr := f.Stat()
 	// TODO(rost): Returning 405 Method Not Allowed might not be appropriate.
 	if copyErr != nil {
 		return http.StatusMethodNotAllowed, copyErr

--- a/webdav/webdav.go
+++ b/webdav/webdav.go
@@ -270,16 +270,16 @@ func (h *Handler) handlePut(w http.ResponseWriter, r *http.Request) (status int,
 	}
 	_, copyErr := io.Copy(f, r.Body)
 	closeErr := f.Close()
-	fi, statErr := f.Stat()
 	// TODO(rost): Returning 405 Method Not Allowed might not be appropriate.
 	if copyErr != nil {
 		return http.StatusMethodNotAllowed, copyErr
 	}
-	if statErr != nil {
-		return http.StatusMethodNotAllowed, statErr
-	}
 	if closeErr != nil {
 		return http.StatusMethodNotAllowed, closeErr
+	}
+	fi, statErr := f.Stat()
+	if statErr != nil {
+		return http.StatusMethodNotAllowed, statErr
 	}
 	etag, err := findETag(ctx, h.FileSystem, h.LockSystem, reqPath, fi)
 	if err != nil {


### PR DESCRIPTION
Hi,

I'm adding WebDav support to [SFTPGo](https://github.com/drakkan/sftpgo). Using the local filesystem all is fine but if I upload a file to a remote filesystem (S3,GCS) the file does not exists until `Close` is called. The webdav package calls `Stat` before `Close` and so I get a 404 error from the Cloud Backend. 

I can easily workaround this issue by returning a fake `os.Fileinfo` without issuing a `Stat` to the Cloud Backend, anyway even for local filesystem seems cleaner to close the file before calling `Stat`.

Thank you!