### PR TITLE
add http2 health check parameters for ConfigureTransport

### DIFF
--- a/http2/transport_test.go
+++ b/http2/transport_test.go
@@ -596,7 +596,7 @@ func TestTransportDialTLS(t *testing.T) {
 
 func TestConfigureTransport(t *testing.T) {
 	t1 := &http.Transport{}
-	err := ConfigureTransport(t1)
+	err := ConfigureTransport(t1, WithReadIdleTimeout(3*time.Second), WithPingTimeout(1*time.Second))
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Currently, `ConfigureTransport` can't configure http2 health check parameters(i.e. http2.Transport.ReadIdleTimeout and http2.Transport.PingTimeout). 
This PR add http2 health check transportOption for ConfigureTransport when configures a net/http HTTP/1 Transport to use HTTP/2. 

Signed-off-by: duyanghao <1294057873@qq.com>