### PR TITLE
http2: compare Content-Encoding case-insensitive

### DIFF
--- a/http2/transport.go
+++ b/http2/transport.go
@@ -2313,7 +2313,7 @@ func (rl *clientConnReadLoop) handleResponse(cs *clientStream, f *MetaHeadersFra
 	cs.bytesRemain = res.ContentLength
 	res.Body = transportResponseBody{cs}
 
-	if cs.requestedGzip && res.Header.Get("Content-Encoding") == "gzip" {
+	if cs.requestedGzip && asciiEqualFold(res.Header.Get("Content-Encoding"), "gzip") {
 		res.Header.Del("Content-Encoding")
 		res.Header.Del("Content-Length")
 		res.ContentLength = -1


### PR DESCRIPTION
RFC7230 states that Content-Encoding should be case insensitive, however the current http2 library only checks for lowercase, this PR checks for gzip using `EqualFold` as the http/1 library does. https://tools.ietf.org/html/rfc7230#section-4