### PR TITLE
dns/dnsmessage: add support for draft-ietf-dnsop-svcb-https-01 RR type

### DIFF
--- a/dns/dnsmessage/message.go
+++ b/dns/dnsmessage/message.go
@@ -14,6 +14,7 @@ package dnsmessage
 
 import (
 	"errors"
+	"sort"
 )
 
 // Message formats
@@ -33,6 +34,8 @@ const (
 	TypeAAAA  Type = 28
 	TypeSRV   Type = 33
 	TypeOPT   Type = 41
+	TypeSVCB  Type = 64
+	TypeHTTPS Type = 65
 
 	// Question.Type
 	TypeWKS   Type = 11
@@ -1023,6 +1026,42 @@ func (p *Parser) OPTResource() (OPTResource, error) {
 	return r, nil
 }
 
+// SVCBResource parses a single SVCBResource.
+//
+// One of the XXXHeader methods must have been called before calling this
+// method.
+func (p *Parser) SVCBResource() (SVCBResource, error) {
+	if !p.resHeaderValid || p.resHeader.Type != TypeSVCB {
+		return SVCBResource{}, ErrNotStarted
+	}
+	r, err := unpackSVCBResource(p.msg, p.off, p.resHeader.Length)
+	if err != nil {
+		return SVCBResource{}, err
+	}
+	p.off += int(p.resHeader.Length)
+	p.resHeaderValid = false
+	p.index++
+	return r, nil
+}
+
+// HTTPSResource parses a single HTTPSResource.
+//
+// One of the XXXHeader methods must have been called before calling this
+// method.
+func (p *Parser) HTTPSResource() (HTTPSResource, error) {
+	if !p.resHeaderValid || p.resHeader.Type != TypeHTTPS {
+		return HTTPSResource{}, ErrNotStarted
+	}
+	r, err := unpackHTTPSResource(p.msg, p.off, p.resHeader.Length)
+	if err != nil {
+		return HTTPSResource{}, err
+	}
+	p.off += int(p.resHeader.Length)
+	p.resHeaderValid = false
+	p.index++
+	return r, nil
+}
+
 // Unpack parses a full Message.
 func (m *Message) Unpack(msg []byte) error {
 	var p Parser
@@ -1546,6 +1585,54 @@ func (b *Builder) OPTResource(h ResourceHeader, r OPTResource) error {
 	preLen := len(msg)
 	if msg, err = r.pack(msg, b.compression, b.start); err != nil {
 		return &nestedError{"OPTResource body", err}
+	}
+	if err := h.fixLen(msg, lenOff, preLen); err != nil {
+		return err
+	}
+	if err := b.incrementSectionCount(); err != nil {
+		return err
+	}
+	b.msg = msg
+	return nil
+}
+
+// SVCBResource adds a single SVCBResource.
+func (b *Builder) SVCBResource(h ResourceHeader, r SVCBResource) error {
+	if err := b.checkResourceSection(); err != nil {
+		return err
+	}
+	h.Type = r.realType()
+	msg, lenOff, err := h.pack(b.msg, b.compression, b.start)
+	if err != nil {
+		return &nestedError{"ResourceHeader", err}
+	}
+	preLen := len(msg)
+	if msg, err = r.pack(msg, b.compression, b.start); err != nil {
+		return &nestedError{"SVCBResource body", err}
+	}
+	if err := h.fixLen(msg, lenOff, preLen); err != nil {
+		return err
+	}
+	if err := b.incrementSectionCount(); err != nil {
+		return err
+	}
+	b.msg = msg
+	return nil
+}
+
+// HTTPSResource adds a single HTTPSResource.
+func (b *Builder) HTTPSResource(h ResourceHeader, r HTTPSResource) error {
+	if err := b.checkResourceSection(); err != nil {
+		return err
+	}
+	h.Type = r.realType()
+	msg, lenOff, err := h.pack(b.msg, b.compression, b.start)
+	if err != nil {
+		return &nestedError{"ResourceHeader", err}
+	}
+	preLen := len(msg)
+	if msg, err = r.pack(msg, b.compression, b.start); err != nil {
+		return &nestedError{"HTTPSResource body", err}
 	}
 	if err := h.fixLen(msg, lenOff, preLen); err != nil {
 		return err
@@ -2135,6 +2222,16 @@ func unpackResourceBody(msg []byte, off int, hdr ResourceHeader) (ResourceBody, 
 		rb, err = unpackOPTResource(msg, off, hdr.Length)
 		r = &rb
 		name = "OPT"
+	case TypeSVCB:
+		var rb SVCBResource
+		rb, err = unpackSVCBResource(msg, off, hdr.Length)
+		r = &rb
+		name = "SVCB"
+	case TypeHTTPS:
+		var rb HTTPSResource
+		rb, err = unpackHTTPSResource(msg, off, hdr.Length)
+		r = &rb
+		name = "HTTPS"
 	}
 	if err != nil {
 		return nil, off, &nestedError{name + " record", err}
@@ -2584,4 +2681,190 @@ func unpackOPTResource(msg []byte, off int, length uint16) (OPTResource, error) 
 		opts = append(opts, o)
 	}
 	return OPTResource{opts}, nil
+}
+
+// An SVCBResource is an SVCB Resource record.
+type SVCBResource struct {
+	Priority uint16
+	Target   Name
+	Params   []Param
+}
+
+type ParamKey uint16
+
+const (
+	ParamMandatory     ParamKey = 0
+	ParamALPN          ParamKey = 1
+	ParamNoDefaultALPN ParamKey = 2
+	ParamPort          ParamKey = 3
+	ParamIPv4Hint      ParamKey = 4
+	ParamECHConfig     ParamKey = 5
+	ParamIPv6Hint      ParamKey = 6
+)
+
+var paramNames = map[ParamKey]string{
+	ParamMandatory:     "mandatory",
+	ParamALPN:          "alpn",
+	ParamNoDefaultALPN: "no-default-alpn",
+	ParamPort:          "port",
+	ParamIPv4Hint:      "ipv4hint",
+	ParamECHConfig:     "echconfig",
+	ParamIPv6Hint:      "ipv6hint",
+}
+
+var paramGoNames = map[ParamKey]string{
+	ParamMandatory:     "ParamMandatory",
+	ParamALPN:          "ParamALPN",
+	ParamNoDefaultALPN: "ParamNoDefaultALPN",
+	ParamPort:          "ParamPort",
+	ParamIPv4Hint:      "ParamIPv4Hint",
+	ParamECHConfig:     "ParamECHConfig",
+	ParamIPv6Hint:      "ParamIPv6Hint",
+}
+
+// String implements fmt.Stringer.String.
+func (t ParamKey) String() string {
+	if n, ok := paramNames[t]; ok {
+		return n
+	}
+	return "key" + printUint16(uint16(t))
+}
+
+// GoString implements fmt.GoStringer.GoString.
+func (t ParamKey) GoString() string {
+	if n, ok := paramGoNames[t]; ok {
+		return "dnsmessage." + n
+	}
+	return printUint16(uint16(t))
+}
+
+type Param struct {
+	Key   ParamKey
+	Value []byte
+}
+
+func (p Param) GoString() string {
+	return "dnsmessage.Param{" +
+		"Key: " + p.Key.GoString() + ", " +
+		`Value: "` + printString(p.Value) + `"}`
+}
+
+func (r *SVCBResource) realType() Type {
+	return TypeSVCB
+}
+
+// pack appends the wire format of the SVCBResource to msg.
+func (r *SVCBResource) pack(msg []byte, compression map[string]int, compressionOff int) ([]byte, error) {
+	return svcbPack(*r, "SVCBResource", msg, compression, compressionOff)
+}
+
+func svcbPack(r SVCBResource, rrTypeName string, msg []byte, compression map[string]int, compressionOff int) ([]byte, error) {
+	oldMsg := msg
+	msg = packUint16(msg, r.Priority)
+	msg, err := r.Target.pack(msg, nil, compressionOff)
+	if err != nil {
+		return oldMsg, &nestedError{rrTypeName + ".Target", err}
+	}
+	if len(r.Params) == 0 {
+		return msg, nil
+	}
+	// SvcParamKeys SHALL appear in increasing numeric order
+	params := append([]Param{}, r.Params...)
+	sort.Slice(params, func(i, j int) bool {
+		return params[i].Key < params[j].Key
+	})
+	for _, p := range params {
+		msg = packUint16(msg, uint16(p.Key))
+		l := uint16(len(p.Value))
+		msg = packUint16(msg, l)
+		msg = packBytes(msg, p.Value)
+	}
+	return msg, nil
+}
+
+// GoString implements fmt.GoStringer.GoString.
+func (r *SVCBResource) GoString() string {
+	s := "dnsmessage.SVCBResource{" +
+		"Priority: " + printUint16(r.Priority) + ", " +
+		"Target: " + r.Target.GoString() +
+		"Params: []dnsmessage.Param{"
+	if len(r.Params) == 0 {
+		return s + "}}"
+	}
+	s += r.Params[0].GoString()
+	for _, p := range r.Params[1:] {
+		s += ", " + p.GoString()
+	}
+	return s + "}}"
+}
+
+func unpackSVCBResource(msg []byte, off int, length uint16) (SVCBResource, error) {
+	endOff := off + int(length)
+	priority, off, err := unpackUint16(msg, off)
+	if err != nil {
+		return SVCBResource{}, &nestedError{"Priority", err}
+	}
+	var target Name
+	if off, err = target.unpackCompressed(msg, off, true /* allowCompression */); err != nil {
+		return SVCBResource{}, &nestedError{"Target", err}
+	}
+	var params []Param
+	for off < endOff {
+		var err error
+		var p Param
+		var k uint16
+		k, off, err = unpackUint16(msg, off)
+		p.Key = ParamKey(k)
+		if err != nil {
+			return SVCBResource{}, &nestedError{"Key", err}
+		}
+		var l uint16
+		l, off, err = unpackUint16(msg, off)
+		if err != nil {
+			return SVCBResource{}, &nestedError{"Value", err}
+		}
+		p.Value = make([]byte, l)
+		if copy(p.Value, msg[off:]) != int(l) {
+			return SVCBResource{}, &nestedError{"Value", errCalcLen}
+		}
+		off += int(l)
+		params = append(params, p)
+	}
+	return SVCBResource{priority, target, params}, nil
+}
+
+type HTTPSResource struct {
+	Priority uint16
+	Target   Name
+	Params   []Param
+}
+
+func (r *HTTPSResource) realType() Type {
+	return TypeHTTPS
+}
+
+// pack appends the wire format of the SVCBResource to msg.
+func (r *HTTPSResource) pack(msg []byte, compression map[string]int, compressionOff int) ([]byte, error) {
+	return svcbPack(SVCBResource(*r), "HTTPSResource", msg, compression, compressionOff)
+}
+
+// GoString implements fmt.GoStringer.GoString.
+func (r *HTTPSResource) GoString() string {
+	s := "dnsmessage.HTTPSResource{" +
+		"Priority: " + printUint16(r.Priority) + ", " +
+		"Target: " + r.Target.GoString() +
+		"Params: []dnsmessage.Param{"
+	if len(r.Params) == 0 {
+		return s + "}}"
+	}
+	s += r.Params[0].GoString()
+	for _, p := range r.Params[1:] {
+		s += ", " + p.GoString()
+	}
+	return s + "}}"
+}
+
+func unpackHTTPSResource(msg []byte, off int, length uint16) (HTTPSResource, error) {
+	r, err := unpackSVCBResource(msg, off, length)
+	return HTTPSResource(r), err
 }

--- a/dns/dnsmessage/message_test.go
+++ b/dns/dnsmessage/message_test.go
@@ -665,6 +665,8 @@ func TestBuilderResourceError(t *testing.T) {
 		{"AResource", func(b *Builder) error { return b.AResource(ResourceHeader{}, AResource{}) }},
 		{"AAAAResource", func(b *Builder) error { return b.AAAAResource(ResourceHeader{}, AAAAResource{}) }},
 		{"OPTResource", func(b *Builder) error { return b.OPTResource(ResourceHeader{}, OPTResource{}) }},
+		{"SVCBResource", func(b *Builder) error { return b.SVCBResource(ResourceHeader{}, SVCBResource{}) }},
+		{"HTTPSResource", func(b *Builder) error { return b.HTTPSResource(ResourceHeader{}, HTTPSResource{}) }},
 	}
 
 	envs := []struct {
@@ -754,6 +756,14 @@ func TestBuilder(t *testing.T) {
 		case TypeSRV:
 			if err := b.SRVResource(a.Header, *a.Body.(*SRVResource)); err != nil {
 				t.Fatalf("Builder.SRVResource(%#v) = %v", a, err)
+			}
+		case TypeSVCB:
+			if err := b.SVCBResource(a.Header, *a.Body.(*SVCBResource)); err != nil {
+				t.Fatalf("Builder.SVCBResource(%#v) = %v", a, err)
+			}
+		case TypeHTTPS:
+			if err := b.HTTPSResource(a.Header, *a.Body.(*HTTPSResource)); err != nil {
+				t.Fatalf("Builder.HTTPSResource(%#v) = %v", a, err)
 			}
 		}
 	}
@@ -1399,6 +1409,30 @@ func largeTestMsg() Message {
 					9,
 					11,
 					MustNewName("srv.example.com."),
+				},
+			},
+			{
+				ResourceHeader{
+					Name:  name,
+					Type:  TypeSVCB,
+					Class: ClassINET,
+				},
+				&SVCBResource{
+					0,
+					MustNewName("svcb.example.com."),
+					[]Param{Param{ParamIPv4Hint, []byte{1, 2, 3, 4}}},
+				},
+			},
+			{
+				ResourceHeader{
+					Name:  name,
+					Type:  TypeSVCB,
+					Class: ClassINET,
+				},
+				&HTTPSResource{
+					0,
+					MustNewName("https.example.com."),
+					[]Param{Param{ParamIPv4Hint, []byte{1, 2, 3, 4}}},
 				},
 			},
 		},


### PR DESCRIPTION
This change adds support for SVCB and its sister HTTPS record types. The
new type Param is used for both records and the parsing/packing is
shared between them as both records are stickly identical on the wire.

For golang/go#43790