### PR TITLE
webdav: release locks when deleting

### DIFF
--- a/webdav/webdav.go
+++ b/webdav/webdav.go
@@ -169,6 +169,22 @@ func (h *Handler) confirmLocks(r *http.Request, src, dst string) (release func()
 	return nil, http.StatusPreconditionFailed, ErrLocked
 }
 
+func (h *Handler) deleteLocks(reqPath string) (status int, err error) {
+	deleter, ok := h.LockSystem.(LockDeleter)
+	if !ok {
+		// Can't delete -- system doesn't support it. Assume it can handle this case
+		return 0, nil
+	}
+
+	err = deleter.Delete(time.Now(), reqPath)
+	if err != nil {
+		return http.StatusInternalServerError, err
+	}
+
+	return 0, nil
+
+}
+
 func (h *Handler) handleOptions(w http.ResponseWriter, r *http.Request) (status int, err error) {
 	reqPath, status, err := h.stripPrefix(r.URL.Path)
 	if err != nil {
@@ -246,6 +262,10 @@ func (h *Handler) handleDelete(w http.ResponseWriter, r *http.Request) (status i
 	}
 	if err := h.FileSystem.RemoveAll(ctx, reqPath); err != nil {
 		return http.StatusMethodNotAllowed, err
+	}
+
+	if status, err := h.deleteLocks(reqPath); err != nil {
+		return status, err
 	}
 	return http.StatusNoContent, nil
 }
@@ -386,7 +406,17 @@ func (h *Handler) handleCopyMove(w http.ResponseWriter, r *http.Request) (status
 			return http.StatusBadRequest, errInvalidDepth
 		}
 	}
-	return moveFiles(ctx, h.FileSystem, src, dst, r.Header.Get("Overwrite") == "T")
+	status, err = moveFiles(ctx, h.FileSystem, src, dst, r.Header.Get("Overwrite") == "T")
+	if status < 200 || status > 300 {
+		return status, err
+	}
+
+	delStatus, err := h.deleteLocks(src)
+	if err != nil {
+		return delStatus, err
+	}
+
+	return status, err
 }
 
 func (h *Handler) handleLock(w http.ResponseWriter, r *http.Request) (retStatus int, retErr error) {


### PR DESCRIPTION
The WebDAV RFC indicates that locks rooted on deleted resource MUST be
destroyed. The WebDAV server does not do this with the builtin in-memory
lock system (memLS). This commit adds a new interface, implemented by
memLS, which allows for deleting locks rooted at a given resource.

We added a new interface rather than extending or changing the existing
one to avoid breaking backwards compatibility with other implementations
of the LockSystem interface. The WebDAV server will behave as it used to
if using a LockSystem which has not implemented the new interface.

We apply the same operation for moved files. This follows from the
WebDAV RFC which indicates that a move is logically a copy followed by
consitency checks, followed by a delete of the source.

Fixes golang/go#42839