### PR TITLE
x/net/http2: allow sending 1xx responses

### DIFF
--- a/http2/server.go
+++ b/http2/server.go
@@ -2674,13 +2674,6 @@ func (rws *responseWriterState) writeHeader(code int) {
 
 	// Handle informational headers, except 100 (Continue) which is handled automatically
 	if code >= 100 && code < 200 {
-		if code == 100 && rws.body.needsContinue {
-			rws.body.needsContinue = false
-			rws.conn.write100ContinueHeaders(rws.body.stream)
-
-			return
-		}
-
 		// Per RFC 8297 we must not clear the current header map
 		h := rws.handlerHeader
 

--- a/http2/server.go
+++ b/http2/server.go
@@ -2645,8 +2645,7 @@ func checkWriteHeaderCode(code int) {
 	// Issue 22880: require valid WriteHeader status codes.
 	// For now we only enforce that it's three digits.
 	// In the future we might block things over 599 (600 and above aren't defined
-	// at http://httpwg.org/specs/rfc7231.html#status.codes)
-	// and we might block under 200 (once we have more mature 1xx support).
+	// at http://httpwg.org/specs/rfc7231.html#status.codes).
 	// But for now any three digits.
 	//
 	// We used to send "HTTP/1.1 000 0" on the wire in responses but there's
@@ -2667,13 +2666,36 @@ func (w *responseWriter) WriteHeader(code int) {
 }
 
 func (rws *responseWriterState) writeHeader(code int) {
-	if !rws.wroteHeader {
-		checkWriteHeaderCode(code)
-		rws.wroteHeader = true
-		rws.status = code
-		if len(rws.handlerHeader) > 0 {
-			rws.snapHeader = cloneHeader(rws.handlerHeader)
+	if rws.wroteHeader {
+		return
+	}
+
+	checkWriteHeaderCode(code)
+
+	// Handle informational headers, except 100 (Continue) which is handled automatically
+	if code > 100 && code < 200 {
+		var h http.Header
+		if code == 103 {
+			// Per RFC 8297 we must not clear the current header map
+			h = rws.handlerHeader
 		}
+
+		if rws.conn.writeHeaders(rws.stream, &writeResHeaders{
+			streamID:    rws.stream.id,
+			httpResCode: code,
+			h:           h,
+			endStream:   rws.handlerDone && !rws.hasTrailers(),
+		}) != nil {
+			rws.dirty = true
+		}
+
+		return
+	}
+
+	rws.wroteHeader = true
+	rws.status = code
+	if len(rws.handlerHeader) > 0 {
+		rws.snapHeader = cloneHeader(rws.handlerHeader)
 	}
 }
 

--- a/http2/server.go
+++ b/http2/server.go
@@ -2689,6 +2689,10 @@ func (rws *responseWriterState) writeHeader(code int) {
 			rws.dirty = true
 		}
 
+		if code == 103 {
+			rws.bw.Flush()
+		}
+
 		return
 	}
 

--- a/http2/server.go
+++ b/http2/server.go
@@ -2672,8 +2672,8 @@ func (rws *responseWriterState) writeHeader(code int) {
 
 	checkWriteHeaderCode(code)
 
-	// Handle informational headers, except 100 (Continue) which is handled automatically
-	if code >= 100 && code < 200 {
+	// Handle informational headers
+	if code >= 100 && code <= 199 {
 		// Per RFC 8297 we must not clear the current header map
 		h := rws.handlerHeader
 


### PR DESCRIPTION
Currently, it's not possible to send informational responses such as
103 Early Hints or 102 Processing.

This patch allows calling WriteHeader() multiple times in order
to send informational responses before the final one.

If the status code is in the 1xx range, the current content of the header map
is also sent. Its content is not removed after the call to WriteHeader()
because the headers must also be included in the final response.

The Chrome and Fastly teams are starting a large-scale experiment to measure
the real-life impact of the 103 status code.
Using Early Hints is proposed as a (partial) alternative to Server Push,
which are going to be removed from Chrome:
https://groups.google.com/a/chromium.org/g/blink-dev/c/K3rYLvmQUBY/m/21anpFhxAQAJ

Being able to send this status code from servers implemented using Go would
help to see if implementing it in browsers is worth it.

Fixes golang/go#26089.
Fixes golang/go#36734.
Updates golang/go#26088.