### PR TITLE
internal/socket: reuse buffers in recv/sendMsgs

### DIFF
--- a/internal/socket/mmsghdr_unix.go
+++ b/internal/socket/mmsghdr_unix.go
@@ -103,7 +103,7 @@ type mmsghdrsPool struct {
 	p sync.Pool
 }
 
-func (p *mmsghdrsPool) Get(ms []Message) *mmsghdrsPacker {
+func (p *mmsghdrsPool) Get() *mmsghdrsPacker {
 	return p.p.Get().(*mmsghdrsPacker)
 }
 

--- a/internal/socket/mmsghdr_unix.go
+++ b/internal/socket/mmsghdr_unix.go
@@ -7,24 +7,12 @@
 
 package socket
 
-import "net"
+import (
+	"net"
+	"sync"
+)
 
 type mmsghdrs []mmsghdr
-
-func (hs mmsghdrs) pack(ms []Message, parseFn func([]byte, string) (net.Addr, error), marshalFn func(net.Addr) []byte) error {
-	for i := range hs {
-		vs := make([]iovec, len(ms[i].Buffers))
-		var sa []byte
-		if parseFn != nil {
-			sa = make([]byte, sizeofSockaddrInet6)
-		}
-		if marshalFn != nil {
-			sa = marshalFn(ms[i].Addr)
-		}
-		hs[i].Hdr.pack(vs, ms[i].Buffers, ms[i].OOB, sa)
-	}
-	return nil
-}
 
 func (hs mmsghdrs) unpack(ms []Message, parseFn func([]byte, string) (net.Addr, error), hint string) error {
 	for i := range hs {
@@ -40,4 +28,80 @@ func (hs mmsghdrs) unpack(ms []Message, parseFn func([]byte, string) (net.Addr, 
 		}
 	}
 	return nil
+}
+
+// mmsghdrsPacker packs Message-slices into mmsghdrs (re-)using pre-allocated buffers.
+type mmsghdrsPacker struct {
+	// hs are the pre-allocated mmsghdrs.
+	hs mmsghdrs
+	// sockaddrs is the pre-allocated buffer for the Hdr.Name buffers.
+	// We use one large buffer for all messages and slice it up.
+	sockaddrs []byte
+	// vs are the pre-allocated iovecs.
+	// We allocate one large buffer for all messages and slice it up. This allows to reuse the buffer
+	// if the number of buffers per message is distributed differently between calls.
+	vs []iovec
+}
+
+func (p *mmsghdrsPacker) prepare(ms []Message) {
+	n := len(ms)
+	if len(p.hs) < n {
+		p.hs = make(mmsghdrs, n)
+	}
+	if len(p.sockaddrs) < n*sizeofSockaddrInet6 {
+		p.sockaddrs = make([]byte, n*sizeofSockaddrInet6)
+	}
+
+	nb := 0
+	for _, m := range ms {
+		nb += len(m.Buffers)
+	}
+	if len(p.vs) < nb {
+		p.vs = make([]iovec, nb)
+	}
+}
+
+func (p *mmsghdrsPacker) pack(ms []Message, parseFn func([]byte, string) (net.Addr, error), marshalFn func(net.Addr, []byte) int) mmsghdrs {
+	hs := p.hs[:len(ms)]
+	vsRest := p.vs
+	saRest := p.sockaddrs
+	for i := range hs {
+		nvs := len(ms[i].Buffers)
+		vs := vsRest[:nvs]
+		vsRest = vsRest[nvs:]
+
+		var sa []byte
+		if parseFn != nil {
+			sa = saRest[:sizeofSockaddrInet6]
+			saRest = saRest[sizeofSockaddrInet6:]
+		} else if marshalFn != nil {
+			n := marshalFn(ms[i].Addr, saRest)
+			sa = saRest[:n]
+			saRest = saRest[n:]
+		}
+		hs[i].Hdr.pack(vs, ms[i].Buffers, ms[i].OOB, sa)
+	}
+	return hs
+}
+
+var defaultMmsghdrsPool = mmsghdrsPool{
+	p: sync.Pool{
+		New: func() interface{} {
+			return new(mmsghdrsPacker)
+		},
+	},
+}
+
+type mmsghdrsPool struct {
+	p sync.Pool
+}
+
+func (p *mmsghdrsPool) Get(ms []Message) *mmsghdrsPacker {
+	packer, _ := p.p.Get().(*mmsghdrsPacker)
+	packer.prepare(ms)
+	return packer
+}
+
+func (p *mmsghdrsPool) Put(packer *mmsghdrsPacker) {
+	p.p.Put(packer)
 }

--- a/internal/socket/rawconn_mmsg.go
+++ b/internal/socket/rawconn_mmsg.go
@@ -17,14 +17,13 @@ func (c *Conn) recvMsgs(ms []Message, flags int) (int, error) {
 	for i := range ms {
 		ms[i].raceWrite()
 	}
-	hs := make(mmsghdrs, len(ms))
+	packer := defaultMmsghdrsPool.Get(ms)
+	defer defaultMmsghdrsPool.Put(packer)
 	var parseFn func([]byte, string) (net.Addr, error)
 	if c.network != "tcp" {
 		parseFn = parseInetAddr
 	}
-	if err := hs.pack(ms, parseFn, nil); err != nil {
-		return 0, err
-	}
+	hs := packer.pack(ms, parseFn, nil)
 	var operr error
 	var n int
 	fn := func(s uintptr) bool {
@@ -50,14 +49,13 @@ func (c *Conn) sendMsgs(ms []Message, flags int) (int, error) {
 	for i := range ms {
 		ms[i].raceRead()
 	}
-	hs := make(mmsghdrs, len(ms))
-	var marshalFn func(net.Addr) []byte
+	packer := defaultMmsghdrsPool.Get(ms)
+	defer defaultMmsghdrsPool.Put(packer)
+	var marshalFn func(net.Addr, []byte) int
 	if c.network != "tcp" {
 		marshalFn = marshalInetAddr
 	}
-	if err := hs.pack(ms, nil, marshalFn); err != nil {
-		return 0, err
-	}
+	hs := packer.pack(ms, nil, marshalFn)
 	var operr error
 	var n int
 	fn := func(s uintptr) bool {

--- a/internal/socket/rawconn_mmsg.go
+++ b/internal/socket/rawconn_mmsg.go
@@ -17,7 +17,7 @@ func (c *Conn) recvMsgs(ms []Message, flags int) (int, error) {
 	for i := range ms {
 		ms[i].raceWrite()
 	}
-	packer := defaultMmsghdrsPool.Get(ms)
+	packer := defaultMmsghdrsPool.Get()
 	defer defaultMmsghdrsPool.Put(packer)
 	var parseFn func([]byte, string) (net.Addr, error)
 	if c.network != "tcp" {
@@ -49,7 +49,7 @@ func (c *Conn) sendMsgs(ms []Message, flags int) (int, error) {
 	for i := range ms {
 		ms[i].raceRead()
 	}
-	packer := defaultMmsghdrsPool.Get(ms)
+	packer := defaultMmsghdrsPool.Get()
 	defer defaultMmsghdrsPool.Put(packer)
 	var marshalFn func(net.Addr, []byte) int
 	if c.network != "tcp" {

--- a/internal/socket/rawconn_msg.go
+++ b/internal/socket/rawconn_msg.go
@@ -55,9 +55,9 @@ func (c *Conn) sendMsg(m *Message, flags int) error {
 	vs := make([]iovec, len(m.Buffers))
 	var sa []byte
 	if m.Addr != nil {
-		sa = make([]byte, sizeofSockaddrInet6)
-		n := marshalInetAddr(m.Addr, sa)
-		sa = sa[:n]
+		var a [sizeofSockaddrInet6]byte
+		n := marshalInetAddr(m.Addr, a[:])
+		sa = a[:n]
 	}
 	h.pack(vs, m.Buffers, m.OOB, sa)
 	var operr error

--- a/internal/socket/rawconn_msg.go
+++ b/internal/socket/rawconn_msg.go
@@ -55,7 +55,9 @@ func (c *Conn) sendMsg(m *Message, flags int) error {
 	vs := make([]iovec, len(m.Buffers))
 	var sa []byte
 	if m.Addr != nil {
-		sa = marshalInetAddr(m.Addr)
+		sa = make([]byte, sizeofSockaddrInet6)
+		n := marshalInetAddr(m.Addr, sa)
+		sa = sa[:n]
 	}
 	h.pack(vs, m.Buffers, m.OOB, sa)
 	var operr error


### PR DESCRIPTION
Use a pool to reuse internally allocated temporary buffers, i.e. the
mmsghdrs structures and the associated iovecs and sockaddr buffers.

The temporary buffers obtained from the pool are re-allocated when their
sizes are not sufficient for the current call.
The (hopefully reasonable) assumption is that RecvMsgs and SendMsgs are
called with a somewhat uniform number of Messages/Buffers. If not, the
buffers in the pool will likely be re-allocated a few times until they
reach the size required for the "biggest" caller.

This pooling can significantly reduce the temporary allocations made in
recv/sendMsgs. While the effectiveness of this change clearly depends
on the usage pattern, pressure on the GC, etc., some improvements can
already be observed in the micro-benchmark BenchmarkUDP: the number and
size of allocations per iteration decreases significantly and there is a
small but noticable improvement in time per iteration.

```
name             old time/op    new time/op    delta
UDP/Iter-1-8       5.50µs ± 2%    5.46µs ± 2%     ~     (p=0.055 n=20+20)
UDP/Batch-1-8      5.65µs ± 3%    5.56µs ± 4%   -1.68%  (p=0.011 n=20+20)
UDP/Iter-2-8       11.0µs ± 3%    11.0µs ± 3%     ~     (p=0.645 n=20+20)
UDP/Batch-2-8      8.40µs ± 3%    8.24µs ± 5%   -1.87%  (p=0.012 n=20+20)
UDP/Iter-4-8       22.0µs ± 1%    21.9µs ± 3%     ~     (p=0.437 n=17+20)
UDP/Batch-4-8      13.3µs ± 2%    12.7µs ± 2%   -4.69%  (p=0.000 n=20+20)
UDP/Iter-8-8       44.2µs ± 3%    44.0µs ± 2%     ~     (p=0.551 n=20+20)
UDP/Batch-8-8      24.2µs ± 4%    23.1µs ± 4%   -4.65%  (p=0.000 n=20+20)
UDP/Iter-16-8      87.9µs ± 4%    88.1µs ± 3%     ~     (p=0.708 n=19+20)
UDP/Batch-16-8     45.6µs ± 4%    44.1µs ± 5%   -3.12%  (p=0.000 n=20+20)
UDP/Iter-32-8       175µs ± 4%     176µs ± 4%     ~     (p=0.087 n=20+20)
UDP/Batch-32-8     87.9µs ± 1%    84.5µs ± 6%   -3.78%  (p=0.000 n=19+19)
UDP/Iter-64-8       353µs ± 3%     352µs ± 3%     ~     (p=0.414 n=20+20)
UDP/Batch-64-8      172µs ± 4%     172µs ±11%     ~     (p=0.157 n=20+20)
UDP/Iter-128-8      705µs ± 3%     699µs ± 4%     ~     (p=0.142 n=20+20)
UDP/Batch-128-8     345µs ± 2%     343µs ± 6%     ~     (p=0.134 n=20+20)
UDP/Iter-256-8     1.41ms ± 3%    1.41ms ± 4%     ~     (p=0.758 n=20+20)
UDP/Batch-256-8     692µs ± 4%     685µs ± 4%     ~     (p=0.114 n=20+20)
UDP/Iter-512-8     2.82ms ± 2%    2.81ms ± 2%     ~     (p=0.820 n=20+20)
UDP/Batch-512-8    1.27ms ± 3%    0.75ms ± 6%  -40.62%  (p=0.000 n=20+20)

name             old alloc/op   new alloc/op   delta
UDP/Iter-1-8         408B ± 0%      424B ± 0%   +3.92%  (p=0.000 n=20+20)
UDP/Batch-1-8        440B ± 0%      232B ± 0%  -47.27%  (p=0.000 n=20+20)
UDP/Iter-2-8         816B ± 0%      848B ± 0%   +3.92%  (p=0.000 n=20+20)
UDP/Batch-2-8        696B ± 0%      280B ± 0%  -59.77%  (p=0.000 n=20+20)
UDP/Iter-4-8       1.63kB ± 0%    1.70kB ± 0%   +3.92%  (p=0.000 n=20+20)
UDP/Batch-4-8      1.22kB ± 0%    0.38kB ± 0%  -68.42%  (p=0.000 n=20+20)
UDP/Iter-8-8       3.26kB ± 0%    3.39kB ± 0%   +3.92%  (p=0.000 n=20+20)
UDP/Batch-8-8      2.26kB ± 0%    0.59kB ± 0%  -73.76%  (p=0.000 n=20+20)
UDP/Iter-16-8      6.53kB ± 0%    6.78kB ± 0%   +3.92%  (p=0.000 n=20+20)
UDP/Batch-16-8     4.34kB ± 0%    1.01kB ± 0%  -76.75%  (p=0.000 n=20+20)
UDP/Iter-32-8      13.1kB ± 0%    13.6kB ± 0%   +3.92%  (p=0.000 n=20+20)
UDP/Batch-32-8     8.50kB ± 0%    1.84kB ± 0%  -78.34%  (p=0.000 n=20+18)
UDP/Iter-64-8      26.1kB ± 0%    27.1kB ± 0%   +3.92%  (p=0.000 n=20+20)
UDP/Batch-64-8     16.8kB ± 0%     3.5kB ± 0%  -79.16%  (p=0.000 n=20+20)
UDP/Iter-128-8     52.2kB ± 0%    54.3kB ± 0%   +3.92%  (p=0.000 n=20+20)
UDP/Batch-128-8    33.5kB ± 0%     6.8kB ± 0%  -79.56%  (p=0.000 n=20+16)
UDP/Iter-256-8      104kB ± 0%     109kB ± 0%   +3.92%  (p=0.000 n=20+17)
UDP/Batch-256-8    66.7kB ± 0%    13.5kB ± 0%  -79.77%  (p=0.000 n=20+20)
UDP/Iter-512-8      209kB ± 0%     217kB ± 0%   +3.92%  (p=0.000 n=20+20)
UDP/Batch-512-8     121kB ± 0%      15kB ± 0%  -87.89%  (p=0.000 n=20+20)

name             old allocs/op  new allocs/op  delta
UDP/Iter-1-8         14.0 ± 0%      14.0 ± 0%     ~     (all equal)
UDP/Batch-1-8        14.0 ± 0%       8.0 ± 0%  -42.86%  (p=0.000 n=20+20)
UDP/Iter-2-8         28.0 ± 0%      28.0 ± 0%     ~     (all equal)
UDP/Batch-2-8        20.0 ± 0%      10.0 ± 0%  -50.00%  (p=0.000 n=20+20)
UDP/Iter-4-8         56.0 ± 0%      56.0 ± 0%     ~     (all equal)
UDP/Batch-4-8        32.0 ± 0%      14.0 ± 0%  -56.25%  (p=0.000 n=20+20)
UDP/Iter-8-8          112 ± 0%       112 ± 0%     ~     (all equal)
UDP/Batch-8-8        56.0 ± 0%      22.0 ± 0%  -60.71%  (p=0.000 n=20+20)
UDP/Iter-16-8         224 ± 0%       224 ± 0%     ~     (all equal)
UDP/Batch-16-8        104 ± 0%        38 ± 0%  -63.46%  (p=0.000 n=20+20)
UDP/Iter-32-8         448 ± 0%       448 ± 0%     ~     (all equal)
UDP/Batch-32-8        200 ± 0%        70 ± 0%  -65.00%  (p=0.000 n=20+20)
UDP/Iter-64-8         896 ± 0%       896 ± 0%     ~     (all equal)
UDP/Batch-64-8        392 ± 0%       134 ± 0%  -65.82%  (p=0.000 n=20+20)
UDP/Iter-128-8      1.79k ± 0%     1.79k ± 0%     ~     (all equal)
UDP/Batch-128-8       776 ± 0%       262 ± 0%  -66.24%  (p=0.000 n=20+20)
UDP/Iter-256-8      3.58k ± 0%     3.58k ± 0%     ~     (all equal)
UDP/Batch-256-8     1.54k ± 0%     0.52k ± 0%  -66.45%  (p=0.000 n=20+20)
UDP/Iter-512-8      7.17k ± 0%     7.17k ± 0%     ~     (all equal)
UDP/Batch-512-8     2.61k ± 0%     0.56k ± 0%  -78.48%  (p=0.000 n=20+20)
```

Fixes golang/go#26838