### PR TITLE
internal/socket: handle nil addr in sendMsgs

### DIFF
--- a/internal/socket/mmsghdr_unix.go
+++ b/internal/socket/mmsghdr_unix.go
@@ -83,8 +83,10 @@ func (p *mmsghdrsPacker) pack(ms []Message, parseFn func([]byte, string) (net.Ad
 			saRest = saRest[sizeofSockaddrInet6:]
 		} else if marshalFn != nil {
 			n := marshalFn(ms[i].Addr, saRest)
-			sa = saRest[:n]
-			saRest = saRest[n:]
+			if n > 0 {
+				sa = saRest[:n]
+				saRest = saRest[n:]
+			}
 		}
 		hs[i].Hdr.pack(vs, ms[i].Buffers, ms[i].OOB, sa)
 	}

--- a/internal/socket/msghdr_linux.go
+++ b/internal/socket/msghdr_linux.go
@@ -17,6 +17,9 @@ func (h *msghdr) pack(vs []iovec, bs [][]byte, oob []byte, sa []byte) {
 	if sa != nil {
 		h.Name = (*byte)(unsafe.Pointer(&sa[0]))
 		h.Namelen = uint32(len(sa))
+	} else {
+		h.Name = nil
+		h.Namelen = 0
 	}
 }
 


### PR DESCRIPTION
With the pool to reuse internal allocations for mmsghdrs introduced in
CL 315589, I've accidentally introduced a regression for sending
messages on dialed connections.
Calling sendMsgs with Messages with a nil address would panic during
(*msghdr).pack at msghdr_linux.go:18 when taking address of first
element of 0-sized buffer.
Handle this case by explicitly resetting the Name/Namelen.

Add test cases for writing to connected sockets.