### PR TITLE
x/net/http2: zero-length payload HEADERS frame causes PROTOCOL_ERROR

### DIFF
--- a/http2/frame.go
+++ b/http2/frame.go
@@ -1018,7 +1018,7 @@ func parseHeadersFrame(_ *frameCache, fh FrameHeader, p []byte) (_ Frame, err er
 			return nil, err
 		}
 	}
-	if len(p)-int(padLength) <= 0 {
+	if int(padLength) > len(p) {
 		return nil, streamError(fh.StreamID, ErrCodeProtocol)
 	}
 	hf.headerFragBuf = p[:len(p)-int(padLength)]


### PR DESCRIPTION
As per [RFC7540 Section 6.2](https://httpwg.org/specs/rfc7540.html#HEADERS):

> Padding that *exceeds* the size remaining for the header block fragment MUST be treated as a PROTOCOL_ERROR.

(emphasis added)

Hence the existing check `if len(p)-int(padLength) <= 0` is incorrect
since `=` would have flagged paddings that is *exactly* the size
remaining. The existing check also triggers false positives when the
HEADERS frame has a payload size of 0 and no padding (0 - 0 <= 0).

Fixes https://github.com/golang/go/issues/47851