### PR TITLE
net/http2: omit invalid header value from error message

### DIFF
--- a/http2/errors.go
+++ b/http2/errors.go
@@ -136,7 +136,7 @@ func (e headerFieldNameError) Error() string {
 type headerFieldValueError string
 
 func (e headerFieldValueError) Error() string {
-	return fmt.Sprintf("invalid header field value %q", string(e))
+	return fmt.Sprintf("invalid header field value for %q", string(e))
 }
 
 var (

--- a/http2/frame.go
+++ b/http2/frame.go
@@ -1532,7 +1532,8 @@ func (fr *Framer) readMetaFrame(hf *HeadersFrame) (*MetaHeadersFrame, error) {
 			fr.debugReadLoggerf("http2: decoded hpack field %+v", hf)
 		}
 		if !httpguts.ValidHeaderFieldValue(hf.Value) {
-			invalid = headerFieldValueError(hf.Value)
+			// Don't include the value in the error, because it may be sensitive.
+			invalid = headerFieldValueError(hf.Name)
 		}
 		isPseudo := strings.HasPrefix(hf.Name, ":")
 		if isPseudo {

--- a/http2/frame_test.go
+++ b/http2/frame_test.go
@@ -1068,7 +1068,7 @@ func TestMetaFrameHeader(t *testing.T) {
 			name:          "invalid_field_value",
 			w:             func(f *Framer) { write(f, encodeHeaderRaw(t, "key", "bad_null\x00")) },
 			want:          streamError(1, ErrCodeProtocol),
-			wantErrReason: "invalid header field value \"bad_null\\x00\"",
+			wantErrReason: `invalid header field value for "key"`,
 		},
 	}
 	for i, tt := range tests {

--- a/http2/transport.go
+++ b/http2/transport.go
@@ -1699,7 +1699,8 @@ func (cc *ClientConn) encodeHeaders(req *http.Request, addGzipHeader bool, trail
 		}
 		for _, v := range vv {
 			if !httpguts.ValidHeaderFieldValue(v) {
-				return nil, fmt.Errorf("invalid HTTP header value %q for header %q", v, k)
+				// Don't include the value in the error, because it may be sensitive.
+				return nil, fmt.Errorf("invalid HTTP header value for header %q", k)
 			}
 		}
 	}

--- a/http2/transport_test.go
+++ b/http2/transport_test.go
@@ -1473,7 +1473,7 @@ func TestTransportInvalidTrailer_EmptyFieldName(t *testing.T) {
 	})
 }
 func TestTransportInvalidTrailer_BinaryFieldValue(t *testing.T) {
-	testInvalidTrailer(t, oneHeader, headerFieldValueError("has\nnewline"), func(enc *hpack.Encoder) {
+	testInvalidTrailer(t, oneHeader, headerFieldValueError("x"), func(enc *hpack.Encoder) {
 		enc.WriteField(hpack.HeaderField{Name: "x", Value: "has\nnewline"})
 	})
 }
@@ -2437,7 +2437,7 @@ func TestTransportFailsOnInvalidHeaders(t *testing.T) {
 		},
 		3: {
 			h:       http.Header{"foo": {"foo\x01bar"}},
-			wantErr: `invalid HTTP header value "foo\x01bar" for header "foo"`,
+			wantErr: `invalid HTTP header value for header "foo"`,
 		},
 	}
 


### PR DESCRIPTION
Updates golang/go#43631