### PR TITLE
net/http2: Fix handling of expect continue

### DIFF
--- a/http2/transport.go
+++ b/http2/transport.go
@@ -1244,6 +1244,7 @@ func (cs *clientStream) writeRequest(req *http.Request) (err error) {
 			req.Header["Expect"],
 			"100-continue") {
 		continueTimeout = 0
+	} else if continueTimeout != 0 {
 		cs.on100 = make(chan struct{}, 1)
 	}
 

--- a/http2/transport.go
+++ b/http2/transport.go
@@ -1239,13 +1239,12 @@ func (cs *clientStream) writeRequest(req *http.Request) (err error) {
 	}
 
 	continueTimeout := cc.t.expectContinueTimeout()
-	if continueTimeout != 0 &&
-		!httpguts.HeaderValuesContainsToken(
-			req.Header["Expect"],
-			"100-continue") {
-		continueTimeout = 0
-	} else if continueTimeout != 0 {
-		cs.on100 = make(chan struct{}, 1)
+	if continueTimeout != 0 {
+		if !httpguts.HeaderValuesContainsToken(req.Header["Expect"], "100-continue") {
+			continueTimeout = 0
+		} else {
+			cs.on100 = make(chan struct{}, 1)
+		}
 	}
 
 	// Past this point (where we send request headers), it is possible for


### PR DESCRIPTION
Recent refactoring in the http2 package broke handling of ExpectContinueTimeout, where the client was always waiting for the timeout to pass before sending the body.

Fixes: golang/go#49677