### PR TITLE
fix small typo

### DIFF
--- a/dns/dnsmessage/message.go
+++ b/dns/dnsmessage/message.go
@@ -260,7 +260,7 @@ var (
 	errReserved           = errors.New("segment prefix is reserved")
 	errTooManyPtr         = errors.New("too many pointers (>10)")
 	errInvalidPtr         = errors.New("invalid pointer")
-	errNilResouceBody     = errors.New("nil resource body")
+	errNilResourceBody    = errors.New("nil resource body")
 	errResourceLen        = errors.New("insufficient data for resource body length")
 	errSegTooLong         = errors.New("segment length too long")
 	errZeroSegLen         = errors.New("zero length segment")
@@ -489,7 +489,7 @@ type ResourceBody interface {
 // pack appends the wire format of the Resource to msg.
 func (r *Resource) pack(msg []byte, compression map[string]int, compressionOff int) ([]byte, error) {
 	if r.Body == nil {
-		return msg, errNilResouceBody
+		return msg, errNilResourceBody
 	}
 	oldMsg := msg
 	r.Header.Type = r.Body.realType()

--- a/dns/dnsmessage/message_test.go
+++ b/dns/dnsmessage/message_test.go
@@ -820,7 +820,7 @@ func TestResourcePack(t *testing.T) {
 				},
 				Answers: []Resource{{ResourceHeader{}, nil}},
 			},
-			&nestedError{"packing Answer", errNilResouceBody},
+			&nestedError{"packing Answer", errNilResourceBody},
 		},
 		{
 			Message{
@@ -850,7 +850,7 @@ func TestResourcePack(t *testing.T) {
 				},
 				Additionals: []Resource{{ResourceHeader{}, nil}},
 			},
-			&nestedError{"packing Additional", errNilResouceBody},
+			&nestedError{"packing Additional", errNilResourceBody},
 		},
 	} {
 		_, err := tt.m.Pack()


### PR DESCRIPTION
Fixed typo in variable name `resouce` -> `resource`