### PR TITLE
all: fix go vet warnings

### DIFF
--- a/http2/h2c/h2c_test.go
+++ b/http2/h2c/h2c_test.go
@@ -24,7 +24,7 @@ func TestSettingsAckSwallowWriter(t *testing.T) {
 	var buf bytes.Buffer
 	swallower := newSettingsAckSwallowWriter(bufio.NewWriter(&buf))
 	fw := http2.NewFramer(swallower, nil)
-	fw.WriteSettings(http2.Setting{http2.SettingMaxFrameSize, 2})
+	fw.WriteSettings(http2.Setting{ID: http2.SettingMaxFrameSize, Val: 2})
 	fw.WriteSettingsAck()
 	fw.WriteData(1, true, []byte{})
 	swallower.Flush()

--- a/http2/transport_test.go
+++ b/http2/transport_test.go
@@ -5307,14 +5307,16 @@ func TestTransportFrameBufferReuse(t *testing.T) {
 			defer wg.Done()
 			req, err := http.NewRequest("POST", st.ts.URL, strings.NewReader(filler))
 			if err != nil {
-				t.Fatal(err)
+				t.Error(err)
+				return
 			}
 			req.Header.Set("Big", filler)
 			req.Trailer = make(http.Header)
 			req.Trailer.Set("Big", filler)
 			res, err := tr.RoundTrip(req)
 			if err != nil {
-				t.Fatal(err)
+				t.Error(err)
+				return
 			}
 			if got, want := res.StatusCode, 200; got != want {
 				t.Errorf("StatusCode = %v; want %v", got, want)
@@ -5657,7 +5659,6 @@ func TestTransportRetriesOnStreamProtocolError(t *testing.T) {
 				}
 			}
 		}
-		return nil
 	}
 	ct.run()
 }

--- a/webdav/prop_test.go
+++ b/webdav/prop_test.go
@@ -149,8 +149,8 @@ func TestMemPS(t *testing.T) {
 			op:   "allprop",
 			name: "/file",
 			pnames: []xml.Name{
-				{"DAV:", "resourcetype"},
-				{"foo", "bar"},
+				{Space: "DAV:", Local: "resourcetype"},
+				{Space: "foo", Local: "bar"},
 			},
 			wantPropstats: []Propstat{{
 				Status: http.StatusOK,
@@ -188,7 +188,7 @@ func TestMemPS(t *testing.T) {
 		propOp: []propOp{{
 			op:     "propfind",
 			name:   "/dir",
-			pnames: []xml.Name{{"DAV:", "resourcetype"}},
+			pnames: []xml.Name{{Space: "DAV:", Local: "resourcetype"}},
 			wantPropstats: []Propstat{{
 				Status: http.StatusOK,
 				Props: []Property{{
@@ -199,7 +199,7 @@ func TestMemPS(t *testing.T) {
 		}, {
 			op:     "propfind",
 			name:   "/file",
-			pnames: []xml.Name{{"DAV:", "resourcetype"}},
+			pnames: []xml.Name{{Space: "DAV:", Local: "resourcetype"}},
 			wantPropstats: []Propstat{{
 				Status: http.StatusOK,
 				Props: []Property{{
@@ -214,7 +214,7 @@ func TestMemPS(t *testing.T) {
 		propOp: []propOp{{
 			op:     "propfind",
 			name:   "/dir",
-			pnames: []xml.Name{{"DAV:", "getcontentlanguage"}},
+			pnames: []xml.Name{{Space: "DAV:", Local: "getcontentlanguage"}},
 			wantPropstats: []Propstat{{
 				Status: http.StatusNotFound,
 				Props: []Property{{
@@ -224,7 +224,7 @@ func TestMemPS(t *testing.T) {
 		}, {
 			op:     "propfind",
 			name:   "/dir",
-			pnames: []xml.Name{{"DAV:", "creationdate"}},
+			pnames: []xml.Name{{Space: "DAV:", Local: "creationdate"}},
 			wantPropstats: []Propstat{{
 				Status: http.StatusNotFound,
 				Props: []Property{{
@@ -238,7 +238,7 @@ func TestMemPS(t *testing.T) {
 		propOp: []propOp{{
 			op:     "propfind",
 			name:   "/dir",
-			pnames: []xml.Name{{"DAV:", "getetag"}},
+			pnames: []xml.Name{{Space: "DAV:", Local: "getetag"}},
 			wantPropstats: []Propstat{{
 				Status: http.StatusNotFound,
 				Props: []Property{{
@@ -248,7 +248,7 @@ func TestMemPS(t *testing.T) {
 		}, {
 			op:     "propfind",
 			name:   "/file",
-			pnames: []xml.Name{{"DAV:", "getetag"}},
+			pnames: []xml.Name{{Space: "DAV:", Local: "getetag"}},
 			wantPropstats: []Propstat{{
 				Status: http.StatusOK,
 				Props: []Property{{
@@ -493,7 +493,7 @@ func TestMemPS(t *testing.T) {
 		propOp: []propOp{{
 			op:     "propfind",
 			name:   "/dir",
-			pnames: []xml.Name{{"foo:", "bar"}},
+			pnames: []xml.Name{{Space: "foo:", Local: "bar"}},
 			wantPropstats: []Propstat{{
 				Status: http.StatusNotFound,
 				Props: []Property{{


### PR DESCRIPTION
http2/h2c/h2c_test.go:27:19: golang.org/x/net/http2.Setting composite literal uses unkeyed fields
webdav/prop_test.go:152:5: encoding/xml.Name composite literal uses unkeyed fields
webdav/prop_test.go:153:5: encoding/xml.Name composite literal uses unkeyed fields
webdav/prop_test.go:191:23: encoding/xml.Name composite literal uses unkeyed fields
webdav/prop_test.go:202:23: encoding/xml.Name composite literal uses unkeyed fields
webdav/prop_test.go:217:23: encoding/xml.Name composite literal uses unkeyed fields
webdav/prop_test.go:227:23: encoding/xml.Name composite literal uses unkeyed fields
webdav/prop_test.go:241:23: encoding/xml.Name composite literal uses unkeyed fields
webdav/prop_test.go:251:23: encoding/xml.Name composite literal uses unkeyed fields
webdav/prop_test.go:496:23: encoding/xml.Name composite literal uses unkeyed fields
http2/transport_test.go:5310:5: call to (*T).Fatal from a non-test goroutine
http2/transport_test.go:5317:5: call to (*T).Fatal from a non-test goroutine
http2/transport_test.go:5660:3: unreachable code