### PR TITLE
x/net/http2: exclude some header from 1xx responses

### DIFF
--- a/http2/server.go
+++ b/http2/server.go
@@ -2677,11 +2677,18 @@ func (rws *responseWriterState) writeHeader(code int) {
 		// Per RFC 8297 we must not clear the current header map
 		h := rws.handlerHeader
 
+		_, cl := h["Content-Length"]
+		_, te := h["Transfer-Encoding"]
+		if cl || te {
+			h = h.Clone()
+			h.Del("Content-Length")
+			h.Del("Transfer-Encoding")
+		}
+
 		if rws.conn.writeHeaders(rws.stream, &writeResHeaders{
 			streamID:    rws.stream.id,
 			httpResCode: code,
 			h:           h,
-			noBody:      true,
 			endStream:   rws.handlerDone && !rws.hasTrailers(),
 		}) != nil {
 			rws.dirty = true

--- a/http2/server.go
+++ b/http2/server.go
@@ -2681,6 +2681,7 @@ func (rws *responseWriterState) writeHeader(code int) {
 			streamID:    rws.stream.id,
 			httpResCode: code,
 			h:           h,
+			noBody:      true,
 			endStream:   rws.handlerDone && !rws.hasTrailers(),
 		}) != nil {
 			rws.dirty = true

--- a/http2/server_test.go
+++ b/http2/server_test.go
@@ -4392,6 +4392,7 @@ func TestServerSendsProcessing(t *testing.T) {
 func TestServerSendsEarlyHints(t *testing.T) {
 	testServerResponse(t, func(w http.ResponseWriter, r *http.Request) error {
 		h := w.Header()
+		h.Add("Content-Length", "123")
 		h.Add("Link", "</style.css>; rel=preload; as=style")
 		h.Add("Link", "</script.js>; rel=preload; as=script")
 		w.WriteHeader(http.StatusEarlyHints)
@@ -4437,7 +4438,7 @@ func TestServerSendsEarlyHints(t *testing.T) {
 			{"link", "</script.js>; rel=preload; as=script"},
 			{"link", "</foo.js>; rel=preload; as=script"},
 			{"content-type", "text/plain; charset=utf-8"},
-			{"content-length", "5"},
+			{"content-length", "123"},
 		}
 
 		if !reflect.DeepEqual(goth, wanth) {

--- a/http2/write.go
+++ b/http2/write.go
@@ -181,6 +181,7 @@ type writeResHeaders struct {
 	httpResCode int         // 0 means no ":status" line
 	h           http.Header // may be nil
 	trailers    []string    // if non-nil, which keys of h to write. nil means all.
+	noBody      bool        // if true, Content-Length and Transfer-Encoding will not be set
 	endStream   bool
 
 	date          string
@@ -214,7 +215,12 @@ func (w *writeResHeaders) writeFrame(ctx writeContext) error {
 		encKV(enc, ":status", httpCodeString(w.httpResCode))
 	}
 
-	encodeHeaders(enc, w.h, w.trailers)
+	var excludedKeys map[string]bool
+	if w.noBody {
+		excludedKeys = map[string]bool{"Content-Length": true, "Transfer-Encoding": true}
+	}
+
+	encodeHeaders(enc, w.h, w.trailers, excludedKeys)
 
 	if w.contentType != "" {
 		encKV(enc, "content-type", w.contentType)
@@ -273,7 +279,7 @@ func (w *writePushPromise) writeFrame(ctx writeContext) error {
 	encKV(enc, ":scheme", w.url.Scheme)
 	encKV(enc, ":authority", w.url.Host)
 	encKV(enc, ":path", w.url.RequestURI())
-	encodeHeaders(enc, w.h, nil)
+	encodeHeaders(enc, w.h, nil, nil)
 
 	headerBlock := buf.Bytes()
 	if len(headerBlock) == 0 {
@@ -329,8 +335,9 @@ func (wu writeWindowUpdate) writeFrame(ctx writeContext) error {
 }
 
 // encodeHeaders encodes an http.Header. If keys is not nil, then (k, h[k])
-// is encoded only if k is in keys.
-func encodeHeaders(enc *hpack.Encoder, h http.Header, keys []string) {
+// is encoded only if k is in keys. If excludeKeys is not nil, then
+// (k, k[h]) is encoded only if k is not true in excludeKeys.
+func encodeHeaders(enc *hpack.Encoder, h http.Header, keys []string, excludeKeys map[string]bool) {
 	if keys == nil {
 		sorter := sorterPool.Get().(*sorter)
 		// Using defer here, since the returned keys from the
@@ -340,6 +347,10 @@ func encodeHeaders(enc *hpack.Encoder, h http.Header, keys []string) {
 		keys = sorter.Keys(h)
 	}
 	for _, k := range keys {
+		if excludeKeys[k] {
+			continue
+		}
+
 		vv := h[k]
 		k, ascii := lowerHeader(k)
 		if !ascii {


### PR DESCRIPTION
Content-Length and Transfer-Encoding must not be sent when the response
has no body.

Necessary to fix the tests of golang/go#42597.