### PR TITLE
Update proxy.go

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -19,6 +19,7 @@ import (
 type Dialer interface {
 	// Dial connects to the given address via the proxy.
 	Dial(network, addr string) (c net.Conn, err error)
+	DialContext(ctx context.Context, network, address string) (net.Conn, error)
 }
 
 // Auth contains authentication parameters that specific Dialers may require.


### PR DESCRIPTION
Add dialcontext to prevent the agent from timeout
Before modification：
`
func TestDialer(t *testing.T) {
	dialer, _ := proxy.SOCKS5("tcp", "127.0.0.1:10809", nil, &net.Dialer{
		Timeout:  3 * time.Second,
		Deadline: time.Now().Add(3 * time.Second),
	})
	_, err := dialer.Dial("tcp", "220.181.38.149:443")
	if err != nil {
		return
	}
}
`
=== RUN   TestDialer
--- PASS: TestDialer (60.01s)
PASS

After modification：
`
func TestDialer(t *testing.T) {
	dialer, _ := proxy.SOCKS5("tcp", "127.0.0.1:10809", nil, &net.Dialer{
		Timeout:  3 * time.Second,
		Deadline: time.Now().Add(3 * time.Second),
	})
	ctx, _ := context.WithTimeout(context.Background(), 3*time.Second)
	_, err := dialer.DialContext(ctx, "tcp", "220.181.38.149:443")
	if err != nil {
		return
	}
}
`

=== RUN   TestDialer
--- PASS: TestDialer (3.00s)
PASS





