### PR TITLE
Update install documentation

### DIFF
--- a/http2/h2i/README.md
+++ b/http2/h2i/README.md
@@ -25,7 +25,7 @@ Later:
 ## Installation
 
 ```
-$ go get golang.org/x/net/http2/h2i
+$ go install golang.org/x/net/http2/h2i@latest
 $ h2i <host>
 ```
 


### PR DESCRIPTION
Hello,

The installation documentation seems outdated because `go get` does not work anymore in cli ootb.