### PR TITLE
http2: fix spec document links

### DIFF
--- a/http2/ciphers_test.go
+++ b/http2/ciphers_test.go
@@ -28,7 +28,7 @@ func TestIsBadCipherGood(t *testing.T) {
 	}
 }
 
-// copied from https://http2.github.io/http2-spec/#BadCipherSuites,
+// copied from https://httpwg.org/specs/rfc7540.html#BadCipherSuites,
 var badCiphers = []uint16{
 	cipher_TLS_NULL_WITH_NULL_NULL,
 	cipher_TLS_RSA_WITH_NULL_MD5,

--- a/http2/frame.go
+++ b/http2/frame.go
@@ -23,7 +23,7 @@ const frameHeaderLen = 9
 var padZeros = make([]byte, 255) // zeros for padding
 
 // A FrameType is a registered frame type as defined in
-// http://http2.github.io/http2-spec/#rfc.section.11.2
+// https://httpwg.org/specs/rfc7540.html#rfc.section.11.2
 type FrameType uint8
 
 const (
@@ -146,7 +146,7 @@ func typeFrameParser(t FrameType) frameParser {
 
 // A FrameHeader is the 9 byte header of all HTTP/2 frames.
 //
-// See http://http2.github.io/http2-spec/#FrameHeader
+// See https://httpwg.org/specs/rfc7540.html#FrameHeader
 type FrameHeader struct {
 	valid bool // caller can access []byte fields in the Frame
 
@@ -575,7 +575,7 @@ func (fr *Framer) checkFrameOrder(f Frame) error {
 
 // A DataFrame conveys arbitrary, variable-length sequences of octets
 // associated with a stream.
-// See http://http2.github.io/http2-spec/#rfc.section.6.1
+// See https://httpwg.org/specs/rfc7540.html#rfc.section.6.1
 type DataFrame struct {
 	FrameHeader
 	data []byte
@@ -698,7 +698,7 @@ func (f *Framer) WriteDataPadded(streamID uint32, endStream bool, data, pad []by
 // endpoints communicate, such as preferences and constraints on peer
 // behavior.
 //
-// See http://http2.github.io/http2-spec/#SETTINGS
+// See https://httpwg.org/specs/rfc7540.html#SETTINGS
 type SettingsFrame struct {
 	FrameHeader
 	p []byte
@@ -837,7 +837,7 @@ func (f *Framer) WriteSettingsAck() error {
 // A PingFrame is a mechanism for measuring a minimal round trip time
 // from the sender, as well as determining whether an idle connection
 // is still functional.
-// See http://http2.github.io/http2-spec/#rfc.section.6.7
+// See https://httpwg.org/specs/rfc7540.html#rfc.section.6.7
 type PingFrame struct {
 	FrameHeader
 	Data [8]byte
@@ -870,7 +870,7 @@ func (f *Framer) WritePing(ack bool, data [8]byte) error {
 }
 
 // A GoAwayFrame informs the remote peer to stop creating streams on this connection.
-// See http://http2.github.io/http2-spec/#rfc.section.6.8
+// See https://httpwg.org/specs/rfc7540.html#rfc.section.6.8
 type GoAwayFrame struct {
 	FrameHeader
 	LastStreamID uint32
@@ -934,7 +934,7 @@ func parseUnknownFrame(_ *frameCache, fh FrameHeader, countError func(string), p
 }
 
 // A WindowUpdateFrame is used to implement flow control.
-// See http://http2.github.io/http2-spec/#rfc.section.6.9
+// See https://httpwg.org/specs/rfc7540.html#rfc.section.6.9
 type WindowUpdateFrame struct {
 	FrameHeader
 	Increment uint32 // never read with high bit set
@@ -1123,7 +1123,7 @@ func (f *Framer) WriteHeaders(p HeadersFrameParam) error {
 }
 
 // A PriorityFrame specifies the sender-advised priority of a stream.
-// See http://http2.github.io/http2-spec/#rfc.section.6.3
+// See https://httpwg.org/specs/rfc7540.html#rfc.section.6.3
 type PriorityFrame struct {
 	FrameHeader
 	PriorityParam
@@ -1193,7 +1193,7 @@ func (f *Framer) WritePriority(streamID uint32, p PriorityParam) error {
 }
 
 // A RSTStreamFrame allows for abnormal termination of a stream.
-// See http://http2.github.io/http2-spec/#rfc.section.6.4
+// See https://httpwg.org/specs/rfc7540.html#rfc.section.6.4
 type RSTStreamFrame struct {
 	FrameHeader
 	ErrCode ErrCode
@@ -1225,7 +1225,7 @@ func (f *Framer) WriteRSTStream(streamID uint32, code ErrCode) error {
 }
 
 // A ContinuationFrame is used to continue a sequence of header block fragments.
-// See http://http2.github.io/http2-spec/#rfc.section.6.10
+// See https://httpwg.org/specs/rfc7540.html#rfc.section.6.10
 type ContinuationFrame struct {
 	FrameHeader
 	headerFragBuf []byte
@@ -1266,7 +1266,7 @@ func (f *Framer) WriteContinuation(streamID uint32, endHeaders bool, headerBlock
 }
 
 // A PushPromiseFrame is used to initiate a server stream.
-// See http://http2.github.io/http2-spec/#rfc.section.6.6
+// See https://httpwg.org/specs/rfc7540.html#rfc.section.6.6
 type PushPromiseFrame struct {
 	FrameHeader
 	PromiseID     uint32

--- a/http2/hpack/encode.go
+++ b/http2/hpack/encode.go
@@ -191,7 +191,7 @@ func appendTableSize(dst []byte, v uint32) []byte {
 // bit prefix, to dst and returns the extended buffer.
 //
 // See
-// http://http2.github.io/http2-spec/compression.html#integer.representation
+// https://httpwg.org/specs/rfc7541.html#integer.representation
 func appendVarInt(dst []byte, n byte, i uint64) []byte {
 	k := uint64((1 << n) - 1)
 	if i < k {

--- a/http2/hpack/hpack.go
+++ b/http2/hpack/hpack.go
@@ -59,7 +59,7 @@ func (hf HeaderField) String() string {
 
 // Size returns the size of an entry per RFC 7541 section 4.1.
 func (hf HeaderField) Size() uint32 {
-	// http://http2.github.io/http2-spec/compression.html#rfc.section.4.1
+	// https://httpwg.org/specs/rfc7541.html#rfc.section.4.1
 	// "The size of the dynamic table is the sum of the size of
 	// its entries. The size of an entry is the sum of its name's
 	// length in octets (as defined in Section 5.2), its value's
@@ -158,7 +158,7 @@ func (d *Decoder) SetAllowedMaxDynamicTableSize(v uint32) {
 }
 
 type dynamicTable struct {
-	// http://http2.github.io/http2-spec/compression.html#rfc.section.2.3.2
+	// https://httpwg.org/specs/rfc7541.html#rfc.section.2.3.2
 	table          headerFieldTable
 	size           uint32 // in bytes
 	maxSize        uint32 // current maxSize
@@ -307,27 +307,27 @@ func (d *Decoder) parseHeaderFieldRepr() error {
 	case b&128 != 0:
 		// Indexed representation.
 		// High bit set?
-		// http://http2.github.io/http2-spec/compression.html#rfc.section.6.1
+		// https://httpwg.org/specs/rfc7541.html#rfc.section.6.1
 		return d.parseFieldIndexed()
 	case b&192 == 64:
 		// 6.2.1 Literal Header Field with Incremental Indexing
 		// 0b10xxxxxx: top two bits are 10
-		// http://http2.github.io/http2-spec/compression.html#rfc.section.6.2.1
+		// https://httpwg.org/specs/rfc7541.html#rfc.section.6.2.1
 		return d.parseFieldLiteral(6, indexedTrue)
 	case b&240 == 0:
 		// 6.2.2 Literal Header Field without Indexing
 		// 0b0000xxxx: top four bits are 0000
-		// http://http2.github.io/http2-spec/compression.html#rfc.section.6.2.2
+		// https://httpwg.org/specs/rfc7541.html#rfc.section.6.2.2
 		return d.parseFieldLiteral(4, indexedFalse)
 	case b&240 == 16:
 		// 6.2.3 Literal Header Field never Indexed
 		// 0b0001xxxx: top four bits are 0001
-		// http://http2.github.io/http2-spec/compression.html#rfc.section.6.2.3
+		// https://httpwg.org/specs/rfc7541.html#rfc.section.6.2.3
 		return d.parseFieldLiteral(4, indexedNever)
 	case b&224 == 32:
 		// 6.3 Dynamic Table Size Update
 		// Top three bits are '001'.
-		// http://http2.github.io/http2-spec/compression.html#rfc.section.6.3
+		// https://httpwg.org/specs/rfc7541.html#rfc.section.6.3
 		return d.parseDynamicTableSizeUpdate()
 	}
 
@@ -420,7 +420,7 @@ var errVarintOverflow = DecodingError{errors.New("varint integer overflow")}
 
 // readVarInt reads an unsigned variable length integer off the
 // beginning of p. n is the parameter as described in
-// http://http2.github.io/http2-spec/compression.html#rfc.section.5.1.
+// https://httpwg.org/specs/rfc7541.html#rfc.section.5.1.
 //
 // n must always be between 1 and 8.
 //

--- a/http2/hpack/hpack_test.go
+++ b/http2/hpack/hpack_test.go
@@ -77,26 +77,26 @@ func TestDecoderDecode(t *testing.T) {
 		wantDynTab []HeaderField // newest entry first
 	}{
 		// C.2.1 Literal Header Field with Indexing
-		// http://http2.github.io/http2-spec/compression.html#rfc.section.C.2.1
+		// https://httpwg.org/specs/rfc7541.html#rfc.section.C.2.1
 		{"C.2.1", dehex("400a 6375 7374 6f6d 2d6b 6579 0d63 7573 746f 6d2d 6865 6164 6572"),
 			[]HeaderField{pair("custom-key", "custom-header")},
 			[]HeaderField{pair("custom-key", "custom-header")},
 		},
 
 		// C.2.2 Literal Header Field without Indexing
-		// http://http2.github.io/http2-spec/compression.html#rfc.section.C.2.2
+		// https://httpwg.org/specs/rfc7541.html#rfc.section.C.2.2
 		{"C.2.2", dehex("040c 2f73 616d 706c 652f 7061 7468"),
 			[]HeaderField{pair(":path", "/sample/path")},
 			[]HeaderField{}},
 
 		// C.2.3 Literal Header Field never Indexed
-		// http://http2.github.io/http2-spec/compression.html#rfc.section.C.2.3
+		// https://httpwg.org/specs/rfc7541.html#rfc.section.C.2.3
 		{"C.2.3", dehex("1008 7061 7373 776f 7264 0673 6563 7265 74"),
 			[]HeaderField{{"password", "secret", true}},
 			[]HeaderField{}},
 
 		// C.2.4 Indexed Header Field
-		// http://http2.github.io/http2-spec/compression.html#rfc.section.C.2.4
+		// https://httpwg.org/specs/rfc7541.html#rfc.section.C.2.4
 		{"C.2.4", []byte("\x82"),
 			[]HeaderField{pair(":method", "GET")},
 			[]HeaderField{}},
@@ -134,7 +134,7 @@ type encAndWant struct {
 }
 
 // C.3 Request Examples without Huffman Coding
-// http://http2.github.io/http2-spec/compression.html#rfc.section.C.3
+// https://httpwg.org/specs/rfc7541.html#rfc.section.C.3
 func TestDecodeC3_NoHuffman(t *testing.T) {
 	testDecodeSeries(t, 4096, []encAndWant{
 		{dehex("8286 8441 0f77 7777 2e65 7861 6d70 6c65 2e63 6f6d"),
@@ -182,7 +182,7 @@ func TestDecodeC3_NoHuffman(t *testing.T) {
 }
 
 // C.4 Request Examples with Huffman Coding
-// http://http2.github.io/http2-spec/compression.html#rfc.section.C.4
+// https://httpwg.org/specs/rfc7541.html#rfc.section.C.4
 func TestDecodeC4_Huffman(t *testing.T) {
 	testDecodeSeries(t, 4096, []encAndWant{
 		{dehex("8286 8441 8cf1 e3c2 e5f2 3a6b a0ab 90f4 ff"),
@@ -229,7 +229,7 @@ func TestDecodeC4_Huffman(t *testing.T) {
 	})
 }
 
-// http://http2.github.io/http2-spec/compression.html#rfc.section.C.5
+// https://httpwg.org/specs/rfc7541.html#rfc.section.C.5
 // "This section shows several consecutive header lists, corresponding
 // to HTTP responses, on the same connection. The HTTP/2 setting
 // parameter SETTINGS_HEADER_TABLE_SIZE is set to the value of 256
@@ -299,7 +299,7 @@ func TestDecodeC5_ResponsesNoHuff(t *testing.T) {
 	})
 }
 
-// http://http2.github.io/http2-spec/compression.html#rfc.section.C.6
+// https://httpwg.org/specs/rfc7541.html#rfc.section.C.6
 // "This section shows the same examples as the previous section, but
 // using Huffman encoding for the literal values. The HTTP/2 setting
 // parameter SETTINGS_HEADER_TABLE_SIZE is set to the value of 256

--- a/http2/http2.go
+++ b/http2/http2.go
@@ -55,14 +55,14 @@ const (
 	ClientPreface = "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n"
 
 	// SETTINGS_MAX_FRAME_SIZE default
-	// http://http2.github.io/http2-spec/#rfc.section.6.5.2
+	// https://httpwg.org/specs/rfc7540.html#rfc.section.6.5.2
 	initialMaxFrameSize = 16384
 
 	// NextProtoTLS is the NPN/ALPN protocol negotiated during
 	// HTTP/2's TLS setup.
 	NextProtoTLS = "h2"
 
-	// http://http2.github.io/http2-spec/#SettingValues
+	// https://httpwg.org/specs/rfc7540.html#SettingValues
 	initialHeaderTableSize = 4096
 
 	initialWindowSize = 65535 // 6.9.2 Initial Flow Control Window Size
@@ -111,7 +111,7 @@ func (st streamState) String() string {
 // Setting is a setting parameter: which setting it is, and its value.
 type Setting struct {
 	// ID is which setting is being set.
-	// See http://http2.github.io/http2-spec/#SettingValues
+	// See https://httpwg.org/specs/rfc7540.html#SettingFormat
 	ID SettingID
 
 	// Val is the value.
@@ -143,7 +143,7 @@ func (s Setting) Valid() error {
 }
 
 // A SettingID is an HTTP/2 setting as defined in
-// http://http2.github.io/http2-spec/#iana-settings
+// https://httpwg.org/specs/rfc7540.html#iana-settings
 type SettingID uint16
 
 const (


### PR DESCRIPTION
Spec documents are no longer available on https://http2.github.io,
they are available at https://httpwg.org/specs.