### PR TITLE
http2: send client conn flow control bytes back immediately

### DIFF
--- a/http2/server_test.go
+++ b/http2/server_test.go
@@ -1251,19 +1251,21 @@ func TestServer_Handler_Sends_WindowUpdate(t *testing.T) {
 		EndHeaders:    true,
 	})
 	st.writeData(1, false, []byte("abcdef"))
+	// Expect to immediately get connection level 6 bytes back.
+	st.wantWindowUpdate(0, 6)
+
 	puppet.do(readBodyHandler(t, "abc"))
-	st.wantWindowUpdate(0, 3)
 	st.wantWindowUpdate(1, 3)
 
 	puppet.do(readBodyHandler(t, "def"))
-	st.wantWindowUpdate(0, 3)
 	st.wantWindowUpdate(1, 3)
 
 	st.writeData(1, true, []byte("ghijkl")) // END_STREAM here
+	st.wantWindowUpdate(0, 6)
+
+	// no more stream-level window updates, since END_STREAM
 	puppet.do(readBodyHandler(t, "ghi"))
 	puppet.do(readBodyHandler(t, "jkl"))
-	st.wantWindowUpdate(0, 3)
-	st.wantWindowUpdate(0, 3) // no more stream-level, since END_STREAM
 }
 
 // the version of the TestServer_Handler_Sends_WindowUpdate with padding.
@@ -1286,17 +1288,17 @@ func TestServer_Handler_Sends_WindowUpdate_Padding(t *testing.T) {
 	})
 	st.writeDataPadded(1, false, []byte("abcdef"), []byte{0, 0, 0, 0})
 
-	// Expect to immediately get our 5 bytes of padding back for
-	// both the connection and stream (4 bytes of padding + 1 byte of length)
-	st.wantWindowUpdate(0, 5)
+	// Expect to immediately get our 6 bytes of data + 5 bytes of padding
+	//  back at connection level.
+	// (4 bytes of padding + 1 byte of padding length)
+	st.wantWindowUpdate(0, 11)
+	// Expect to immediately get our 5 bytes of padding back at stream level.
 	st.wantWindowUpdate(1, 5)
 
 	puppet.do(readBodyHandler(t, "abc"))
-	st.wantWindowUpdate(0, 3)
 	st.wantWindowUpdate(1, 3)
 
 	puppet.do(readBodyHandler(t, "def"))
-	st.wantWindowUpdate(0, 3)
 	st.wantWindowUpdate(1, 3)
 }
 


### PR DESCRIPTION
HTTP/2 server must send client connection flow control bytes
back immediately on receiving the data frame. Connection flow control
updates must not depend on whether data has been read by the 
application handler or not. This prevents fast streams from starving 
due to slow streams.

Fixes: golang/go#54330