### PR TITLE
webdav: replace os.SEEK_XXX with io.SeekXXX

### DIFF
--- a/webdav/file.go
+++ b/webdav/file.go
@@ -547,11 +547,11 @@ func (f *memFile) Seek(offset int64, whence int) (int64, error) {
 	npos := f.pos
 	// TODO: How to handle offsets greater than the size of system int?
 	switch whence {
-	case os.SEEK_SET:
+	case io.SeekStart:
 		npos = int(offset)
-	case os.SEEK_CUR:
+	case io.SeekCurrent:
 		npos += int(offset)
-	case os.SEEK_END:
+	case io.SeekEnd:
 		npos = len(f.n.data) + int(offset)
 	default:
 		npos = -1

--- a/webdav/file_test.go
+++ b/webdav/file_test.go
@@ -711,11 +711,11 @@ func TestMemFile(t *testing.T) {
 			default:
 				t.Fatalf("test case #%d %q: invalid seek whence", i, tc)
 			case "set":
-				whence = os.SEEK_SET
+				whence = io.SeekStart
 			case "cur":
-				whence = os.SEEK_CUR
+				whence = io.SeekCurrent
 			case "end":
-				whence = os.SEEK_END
+				whence = io.SeekEnd
 			}
 			offset, err := strconv.Atoi(parts[1])
 			if err != nil {

--- a/webdav/prop.go
+++ b/webdav/prop.go
@@ -425,7 +425,7 @@ func findContentType(ctx context.Context, fs FileSystem, ls LockSystem, name str
 	}
 	ctype = http.DetectContentType(buf[:n])
 	// Rewind file.
-	_, err = f.Seek(0, os.SEEK_SET)
+	_, err = f.Seek(0, io.SeekStart)
 	return ctype, err
 }
 


### PR DESCRIPTION
Because os.SEEK_XXX has been deprecated, using io.SeekXXX instead.