### PR TITLE
dns/dnsmessage: reject names with dots inside label

### DIFF
--- a/dns/dnsmessage/message.go
+++ b/dns/dnsmessage/message.go
@@ -260,6 +260,7 @@ var (
 	errReserved           = errors.New("segment prefix is reserved")
 	errTooManyPtr         = errors.New("too many pointers (>10)")
 	errInvalidPtr         = errors.New("invalid pointer")
+	errInvalidName        = errors.New("invalid dns name")
 	errNilResouceBody     = errors.New("nil resource body")
 	errResourceLen        = errors.New("insufficient data for resource body length")
 	errSegTooLong         = errors.New("segment length too long")
@@ -2034,6 +2035,15 @@ Loop:
 			if endOff > len(msg) {
 				return off, errCalcLen
 			}
+
+			// Reject names containing dots.
+			// See issue golang/go#56246
+			for _, v := range msg[currOff:endOff] {
+				if v == '.' {
+					return off, errInvalidName
+				}
+			}
+
 			name = append(name, msg[currOff:endOff]...)
 			name = append(name, '.')
 			currOff = endOff

--- a/dns/dnsmessage/message_test.go
+++ b/dns/dnsmessage/message_test.go
@@ -211,6 +211,15 @@ func TestName(t *testing.T) {
 	}
 }
 
+func TestNameWithDotsUnpack(t *testing.T) {
+	name := []byte{3, 'w', '.', 'w', 2, 'g', 'o', 3, 'd', 'e', 'v', 0}
+	var n Name
+	_, err := n.unpack(name, 0)
+	if err != errInvalidName {
+		t.Fatalf("expected %v, got %v", errInvalidName, err)
+	}
+}
+
 func TestNamePackUnpack(t *testing.T) {
 	const suffix = ".go.dev."
 	var longDNSPrefix = strings.Repeat("verylongdomainlabel.", 20)


### PR DESCRIPTION
Fixes golang/go#56246