### PR TITLE
http2: calculate a correct window increment size for a stream

### DIFF
--- a/http2/server.go
+++ b/http2/server.go
@@ -2336,13 +2336,13 @@ func (sc *serverConn) sendWindowUpdate(st *stream) {
 
 	var n int32
 	if st == nil {
-		if avail, windowSize := sc.inflow.available(), sc.srv.initialConnRecvWindowSize(); avail > windowSize/2 {
+		if avail, windowSize := sc.inflow.n, sc.srv.initialConnRecvWindowSize(); avail > windowSize/2 {
 			return
 		} else {
 			n = windowSize - avail
 		}
 	} else {
-		if avail, windowSize := st.inflow.available(), sc.srv.initialStreamRecvWindowSize(); avail > windowSize/2 {
+		if avail, windowSize := st.inflow.n, sc.srv.initialStreamRecvWindowSize(); avail > windowSize/2 {
 			return
 		} else {
 			n = windowSize - avail
@@ -2358,7 +2358,7 @@ func (sc *serverConn) sendWindowUpdate(st *stream) {
 		sc.sendWindowUpdate32(st, maxUint31)
 		n -= maxUint31
 	}
-	sc.sendWindowUpdate32(st, int32(n))
+	sc.sendWindowUpdate32(st, n)
 }
 
 // st may be nil for conn-level


### PR DESCRIPTION
CL 432038 reduces sending WindowUpdates by introducing a threshold. Once
the remaining bytes are below the threshold, a single WindowUpdate is
sent to reset the amount back to the maximum amount configured.

The window increment size for a stream is calculated from:

    sc.srv.initialStreamRecvWindowSize() - st.inflow.available()

Where (*flow).available is defined as:

    func (f *flow) available() int32 {
    	n := f.n
    	if f.conn != nil && f.conn.n < n {
    		n = f.conn.n
    	}
    	return n
    }

When f.conn.c < f.n, it gets a bigger increment size. It should be
calculated from:

    sc.srv.initialStreamRecvWindowSize() - st.inflow.n

While we're here, remove an unnecessary type conversion too.

Updates golang/go#56315.