### PR TITLE
internal/socks: permit authenticating with an empty password

### DIFF
--- a/internal/socks/socks.go
+++ b/internal/socks/socks.go
@@ -289,7 +289,7 @@ func (up *UsernamePassword) Authenticate(ctx context.Context, rw io.ReadWriter, 
 	case AuthMethodNotRequired:
 		return nil
 	case AuthMethodUsernamePassword:
-		if len(up.Username) == 0 || len(up.Username) > 255 || len(up.Password) == 0 || len(up.Password) > 255 {
+		if len(up.Username) == 0 || len(up.Username) > 255 || len(up.Password) > 255 {
 			return errors.New("invalid username/password")
 		}
 		b := []byte{authUsernamePasswordVersion}


### PR DESCRIPTION
The behavior is accepted widely, and I found no reason to deny it.

Fixes golang/go#57285