### PR TITLE
proxy: expand Dialer interface to expose DialContext

### DIFF
--- a/proxy/per_host_test.go
+++ b/proxy/per_host_test.go
@@ -21,6 +21,11 @@ func (r *recordingProxy) Dial(network, addr string) (net.Conn, error) {
 	return nil, errors.New("recordingProxy")
 }
 
+func (r *recordingProxy) DialContext(ctx context.Context, network, addr string) (net.Conn, error) {
+	r.addrs = append(r.addrs, addr)
+	return nil, errors.New("recordingProxy")
+}
+
 func TestPerHost(t *testing.T) {
 	expectedDef := []string{
 		"example.com:123",

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -7,6 +7,7 @@
 package proxy // import "golang.org/x/net/proxy"
 
 import (
+	"context"
 	"errors"
 	"net"
 	"net/url"
@@ -19,6 +20,7 @@ import (
 type Dialer interface {
 	// Dial connects to the given address via the proxy.
 	Dial(network, addr string) (c net.Conn, err error)
+	DialContext(ctx context.Context, network, address string) (net.Conn, error)
 }
 
 // Auth contains authentication parameters that specific Dialers may require.


### PR DESCRIPTION
currently, the Dialer interface returned (from say proxy.SOCKS5()) only exposes the Dial function, while it has a DialContext function as well.  As Dial() usage is deprecated, DialContext should be exposed as well.

All implementations in proxy already had a DialContext function besides a single test recording struct, so added a similiar recorder to it.