### PR TITLE
fix: do not flush immediately after write headers

### DIFF
--- a/http2/transport.go
+++ b/http2/transport.go
@@ -1614,7 +1614,6 @@ func (cc *ClientConn) writeHeaders(streamID uint32, endStream bool, maxFrameSize
 			cc.fr.WriteContinuation(streamID, endHeaders, chunk)
 		}
 	}
-	cc.bw.Flush()
 	return cc.werr
 }
 


### PR DESCRIPTION
See https://github.com/golang/go/issues/58674 for details.