### PR TITLE
http2: handle trailing colon in authorityAddr

### DIFF
--- a/http2/transport.go
+++ b/http2/transport.go
@@ -518,11 +518,14 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 func authorityAddr(scheme string, authority string) (addr string) {
 	host, port, err := net.SplitHostPort(authority)
 	if err != nil { // authority didn't have a port
+		host = authority
+		port = ""
+	}
+	if port == "" { // authority's port was empty
 		port = "443"
 		if scheme == "http" {
 			port = "80"
 		}
-		host = authority
 	}
 	if a, err := idna.ToASCII(host); err == nil {
 		host = a

--- a/http2/transport_test.go
+++ b/http2/transport_test.go
@@ -4467,11 +4467,14 @@ func TestAuthorityAddr(t *testing.T) {
 	}{
 		{"http", "foo.com", "foo.com:80"},
 		{"https", "foo.com", "foo.com:443"},
+		{"https", "foo.com:", "foo.com:443"},
 		{"https", "foo.com:1234", "foo.com:1234"},
 		{"https", "1.2.3.4:1234", "1.2.3.4:1234"},
 		{"https", "1.2.3.4", "1.2.3.4:443"},
+		{"https", "1.2.3.4:", "1.2.3.4:443"},
 		{"https", "[::1]:1234", "[::1]:1234"},
 		{"https", "[::1]", "[::1]:443"},
+		{"https", "[::1]:", "[::1]:443"},
 	}
 	for _, tt := range tests {
 		got := authorityAddr(tt.scheme, tt.authority)


### PR DESCRIPTION
This change modifies the authorityAddr result for authorities with empty
port information, such as "example.com:". Previously, such authorities
passed through the function unchanged. This conflicts with the result
from net/http's canonicalAddr, which returns "example.com:443" (for
HTTPS).

net/http's canonicalAddr result is passed to http2's upgradeFn (defined
inside http2.configureTransports) from net/http's (*Transport).dialConn.
The connection is then added to http2's cache under the canonicalAddr
key. However, cache lookups are performed in (*Transport).RoundTripOpt
using the result from authorityAddr applied directly to the input URL.
The lookup thus fails if authorityAddr and canonicalAddr don't agree.

http2's lookup error propagates upwards to net/http's
(*Transport).roundTrip, where the request is retried. The end result is
an infinite loop of the request being repeated, each time with a freshly
dialed connection, that can only be stopped by a timeout.

Aligning the results of http2's authorityAddr and net/http's
canonicalAddr fixes the bug. While an authority with a trailing colon is
invalid per URL specifications, I have personally come across
misconfigured web servers emitting such URLs as redirects. This is how I
discovered this issue in http2.