### PR TITLE
ipv4,ipv6: remove unneeded deadlines added for flaky tests

### DIFF
--- a/ipv4/multicast_test.go
+++ b/ipv4/multicast_test.go
@@ -11,7 +11,6 @@ import (
 	"os"
 	"runtime"
 	"testing"
-	"time"
 
 	"golang.org/x/net/icmp"
 	"golang.org/x/net/internal/iana"
@@ -98,9 +97,6 @@ func TestPacketConnReadWriteMulticastUDP(t *testing.T) {
 						t.Logf("not supported on %s", runtime.GOOS)
 						continue
 					}
-					t.Fatal(err)
-				}
-				if err := p.SetDeadline(time.Now().Add(200 * time.Millisecond)); err != nil {
 					t.Fatal(err)
 				}
 				if err := p.SetMulticastTTL(i + 1); err != nil {
@@ -215,9 +211,6 @@ func TestPacketConnReadWriteMulticastICMP(t *testing.T) {
 						t.Logf("not supported on %s", runtime.GOOS)
 						continue
 					}
-					t.Fatal(err)
-				}
-				if err := p.SetDeadline(time.Now().Add(200 * time.Millisecond)); err != nil {
 					t.Fatal(err)
 				}
 				if err := p.SetMulticastTTL(i + 1); err != nil {
@@ -335,9 +328,6 @@ func TestRawConnReadWriteMulticastICMP(t *testing.T) {
 					t.Logf("not supported on %s", runtime.GOOS)
 					continue
 				}
-				t.Fatal(err)
-			}
-			if err := r.SetDeadline(time.Now().Add(200 * time.Millisecond)); err != nil {
 				t.Fatal(err)
 			}
 			r.SetMulticastTTL(i + 1)

--- a/ipv4/unicast_test.go
+++ b/ipv4/unicast_test.go
@@ -50,9 +50,6 @@ func TestPacketConnReadWriteUnicastUDP(t *testing.T) {
 			t.Fatal(err)
 		}
 		p.SetTTL(i + 1)
-		if err := p.SetWriteDeadline(time.Now().Add(100 * time.Millisecond)); err != nil {
-			t.Fatal(err)
-		}
 
 		backoff := time.Millisecond
 		for {
@@ -72,9 +69,6 @@ func TestPacketConnReadWriteUnicastUDP(t *testing.T) {
 		}
 
 		rb := make([]byte, 128)
-		if err := p.SetReadDeadline(time.Now().Add(100 * time.Millisecond)); err != nil {
-			t.Fatal(err)
-		}
 		if n, _, _, err := p.ReadFrom(rb); err != nil {
 			t.Fatal(err)
 		} else if !bytes.Equal(rb[:n], wb) {
@@ -130,9 +124,6 @@ func TestPacketConnReadWriteUnicastICMP(t *testing.T) {
 			t.Fatal(err)
 		}
 		p.SetTTL(i + 1)
-		if err := p.SetWriteDeadline(time.Now().Add(100 * time.Millisecond)); err != nil {
-			t.Fatal(err)
-		}
 
 		backoff := time.Millisecond
 		for {
@@ -153,9 +144,6 @@ func TestPacketConnReadWriteUnicastICMP(t *testing.T) {
 
 		rb := make([]byte, 128)
 	loop:
-		if err := p.SetReadDeadline(time.Now().Add(100 * time.Millisecond)); err != nil {
-			t.Fatal(err)
-		}
 		if n, _, _, err := p.ReadFrom(rb); err != nil {
 			t.Fatal(err)
 		} else {
@@ -226,17 +214,11 @@ func TestRawConnReadWriteUnicastICMP(t *testing.T) {
 			}
 			t.Fatal(err)
 		}
-		if err := r.SetWriteDeadline(time.Now().Add(100 * time.Millisecond)); err != nil {
-			t.Fatal(err)
-		}
 		if err := r.WriteTo(wh, wb, nil); err != nil {
 			t.Fatal(err)
 		}
 		rb := make([]byte, ipv4.HeaderLen+128)
 	loop:
-		if err := r.SetReadDeadline(time.Now().Add(100 * time.Millisecond)); err != nil {
-			t.Fatal(err)
-		}
 		if _, b, _, err := r.ReadFrom(rb); err != nil {
 			t.Fatal(err)
 		} else {

--- a/ipv6/unicast_test.go
+++ b/ipv6/unicast_test.go
@@ -57,9 +57,6 @@ func TestPacketConnReadWriteUnicastUDP(t *testing.T) {
 			t.Fatal(err)
 		}
 		cm.HopLimit = i + 1
-		if err := p.SetWriteDeadline(time.Now().Add(100 * time.Millisecond)); err != nil {
-			t.Fatal(err)
-		}
 
 		backoff := time.Millisecond
 		for {
@@ -79,9 +76,6 @@ func TestPacketConnReadWriteUnicastUDP(t *testing.T) {
 		}
 
 		rb := make([]byte, 128)
-		if err := p.SetReadDeadline(time.Now().Add(100 * time.Millisecond)); err != nil {
-			t.Fatal(err)
-		}
 		if n, _, _, err := p.ReadFrom(rb); err != nil {
 			t.Fatal(err)
 		} else if !bytes.Equal(rb[:n], wb) {
@@ -168,9 +162,6 @@ func TestPacketConnReadWriteUnicastICMP(t *testing.T) {
 			t.Fatal(err)
 		}
 		cm.HopLimit = i + 1
-		if err := p.SetWriteDeadline(time.Now().Add(100 * time.Millisecond)); err != nil {
-			t.Fatal(err)
-		}
 
 		backoff := time.Millisecond
 		for {
@@ -190,9 +181,6 @@ func TestPacketConnReadWriteUnicastICMP(t *testing.T) {
 		}
 
 		rb := make([]byte, 128)
-		if err := p.SetReadDeadline(time.Now().Add(100 * time.Millisecond)); err != nil {
-			t.Fatal(err)
-		}
 		if n, _, _, err := p.ReadFrom(rb); err != nil {
 			t.Fatal(err)
 		} else {


### PR DESCRIPTION
Deadlines were added in https://go.dev/cl/21360043, but these are 
unneeded as the tests will fail anyways as a result of the timeout. 
This prevents these timeouts from causing further test flakes.

Fixes #58955