### PR TITLE
websocket: refactor package files

### DIFF
--- a/websocket/client.go
+++ b/websocket/client.go
@@ -69,9 +69,9 @@ var portMap = map[string]string{
 }
 
 func parseAuthority(location *url.URL) string {
-	if _, ok := portMap[location.Scheme]; ok {
+	if port, ok := portMap[location.Scheme]; ok {
 		if _, _, err := net.SplitHostPort(location.Host); err != nil {
-			return net.JoinHostPort(location.Host, portMap[location.Scheme])
+			return net.JoinHostPort(location.Host, port)
 		}
 	}
 	return location.Host

--- a/websocket/server.go
+++ b/websocket/server.go
@@ -6,6 +6,7 @@ package websocket
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -65,7 +66,7 @@ type Server struct {
 	Handler
 }
 
-// ServeHTTP implements the http.Handler interface for a WebSocket
+// ServeHTTP implements the http.Handler interface for a WebSocket.
 func (s Server) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	s.serveWebSocket(w, req)
 }
@@ -101,12 +102,12 @@ type Handler func(*Conn)
 func checkOrigin(config *Config, req *http.Request) (err error) {
 	config.Origin, err = Origin(config, req)
 	if err == nil && config.Origin == nil {
-		return fmt.Errorf("null origin")
+		return errors.New("null origin")
 	}
 	return err
 }
 
-// ServeHTTP implements the http.Handler interface for a WebSocket
+// ServeHTTP implements the http.Handler interface for a WebSocket.
 func (h Handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	s := Server{Handler: h, Handshake: checkOrigin}
 	s.serveWebSocket(w, req)

--- a/websocket/websocket.go
+++ b/websocket/websocket.go
@@ -17,7 +17,6 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/url"
@@ -66,7 +65,7 @@ var (
 )
 
 // ErrFrameTooLarge is returned by Codec's Receive method if payload size
-// exceeds limit set by Conn.MaxPayloadBytes
+// exceeds limit set by Conn.MaxPayloadBytes.
 var ErrFrameTooLarge = errors.New("websocket: frame payload size exceeds limit")
 
 // Addr is an implementation of net.Addr for WebSocket.
@@ -77,7 +76,7 @@ type Addr struct {
 // Network returns the network type for a WebSocket, "websocket".
 func (addr *Addr) Network() string { return "websocket" }
 
-// Config is a WebSocket configuration
+// Config is a WebSocket configuration.
 type Config struct {
 	// A WebSocket server address.
 	Location *url.URL
@@ -208,7 +207,7 @@ again:
 	n, err = ws.frameReader.Read(msg)
 	if err == io.EOF {
 		if trailer := ws.frameReader.TrailerReader(); trailer != nil {
-			io.Copy(ioutil.Discard, trailer)
+			io.Copy(io.Discard, trailer)
 		}
 		ws.frameReader = nil
 		goto again
@@ -330,7 +329,7 @@ func (cd Codec) Receive(ws *Conn, v interface{}) (err error) {
 	ws.rio.Lock()
 	defer ws.rio.Unlock()
 	if ws.frameReader != nil {
-		_, err = io.Copy(ioutil.Discard, ws.frameReader)
+		_, err = io.Copy(io.Discard, ws.frameReader)
 		if err != nil {
 			return err
 		}
@@ -362,7 +361,7 @@ again:
 		return ErrFrameTooLarge
 	}
 	payloadType := frame.PayloadType()
-	data, err := ioutil.ReadAll(frame)
+	data, err := io.ReadAll(frame)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Use map value obtained already to avoid obtaining again.
Replace "msg[i] = msg[i] ^" with "msg[i] ^=".
Simplify generateMaskingKey's return.
Replace "fmt.Errorf" with "errors.New" when there is no verb. 
Replace "ioutil" with "io", since the go version is "1.17".
Fix comments ending with a period;  break a long sentence into two lines, and the new line starts with quantifier "a".