### PR TITLE
http2: update test Dockerfile

### DIFF
--- a/http2/Dockerfile
+++ b/http2/Dockerfile
@@ -1,51 +1,10 @@
 #
-# This Dockerfile builds a recent curl with HTTP/2 client support, using
+# This Dockerfile used to build a recent curl with HTTP/2 client support, using
 # a recent nghttp2 build.
+# Now it just wraps the latest curl build, which has all the requirements.
 #
 # See the Makefile for how to tag it. If Docker and that image is found, the
 # Go tests use this curl binary for integration tests.
 #
 
-FROM ubuntu:trusty
-
-RUN apt-get update && \
-    apt-get upgrade -y && \
-    apt-get install -y git-core build-essential wget
-
-RUN apt-get install -y --no-install-recommends \
-       autotools-dev libtool pkg-config zlib1g-dev \
-       libcunit1-dev libssl-dev libxml2-dev libevent-dev \
-       automake autoconf
-
-# The list of packages nghttp2 recommends for h2load:
-RUN apt-get install -y --no-install-recommends make binutils \
-        autoconf automake autotools-dev \
-        libtool pkg-config zlib1g-dev libcunit1-dev libssl-dev libxml2-dev \
-        libev-dev libevent-dev libjansson-dev libjemalloc-dev \
-        cython python3.4-dev python-setuptools
-
-# Note: setting NGHTTP2_VER before the git clone, so an old git clone isn't cached:
-ENV NGHTTP2_VER 895da9a
-RUN cd /root && git clone https://github.com/tatsuhiro-t/nghttp2.git
-
-WORKDIR /root/nghttp2
-RUN git reset --hard $NGHTTP2_VER
-RUN autoreconf -i
-RUN automake
-RUN autoconf
-RUN ./configure
-RUN make
-RUN make install
-
-WORKDIR /root
-RUN wget https://curl.se/download/curl-7.45.0.tar.gz
-RUN tar -zxvf curl-7.45.0.tar.gz
-WORKDIR /root/curl-7.45.0
-RUN ./configure --with-ssl --with-nghttp2=/usr/local
-RUN make
-RUN make install
-RUN ldconfig
-
-CMD ["-h"]
-ENTRYPOINT ["/usr/local/bin/curl"]
-
+FROM curlimages/curl


### PR DESCRIPTION
This Dockerfile uses an old version of Ubuntu to build curl with http2. 
Why not use the latest curl image from Dockerhub for the same thing?

I noticed this because Snyk reports vulnerabilities for "ubuntu:focal"... pretty sure that is not true, as according to DockerHub the latest version was published ~8 months ago and has 0 vulnerabilities. However, I figured this is an opportunity to simplify. I was not able to get the tests passing with the original version, but they do pass with the change made below.

NOTE: since the Dockerfile no longer does anything important, it *could* be deleted, along with the Makefile. I'm not familiar enough with how this is built to make those changes. Also, I wanted to keep this PR simple and avoid additional effort if it is rejected (or ignored).