### PR TITLE
net/http2: remove awaitGracefulShutdown

### DIFF
--- a/http2/server.go
+++ b/http2/server.go
@@ -1012,14 +1012,6 @@ func (sc *serverConn) serve() {
 	}
 }
 
-func (sc *serverConn) awaitGracefulShutdown(sharedCh <-chan struct{}, privateCh chan struct{}) {
-	select {
-	case <-sc.doneServing:
-	case <-sharedCh:
-		close(privateCh)
-	}
-}
-
 type serverMessage int
 
 // Message values sent to serveMsgCh.


### PR DESCRIPTION
It was added by https://golang.org/cl/43455 and
its usage was removed by https://golang.org/cl/43230

Updates golang/go#20302