### PR TITLE
net/http: document userinfo details regarding HttpProxy.Config

### DIFF
--- a/http/httpproxy/proxy.go
+++ b/http/httpproxy/proxy.go
@@ -27,12 +27,16 @@ import (
 type Config struct {
 	// HTTPProxy represents the value of the HTTP_PROXY or
 	// http_proxy environment variable. It will be used as the proxy
-	// URL for HTTP requests unless overridden by NoProxy.
+	// URL for HTTP requests unless overridden by NoProxy. It may
+	// include user information ("user:password" format) that will
+	// be used as client proxy authentication.
 	HTTPProxy string
 
 	// HTTPSProxy represents the HTTPS_PROXY or https_proxy
 	// environment variable. It will be used as the proxy URL for
-	// HTTPS requests unless overridden by NoProxy.
+	// HTTPS requests unless overridden by NoProxy.  It may
+	// include user information ("user:password" format) that will
+	// be used as client proxy authentication.
 	HTTPSProxy string
 
 	// NoProxy represents the NO_PROXY or no_proxy environment


### PR DESCRIPTION
Document user info support in HttpProxy.Config environment variables,  e.g. HTTPS_PROXY=https://user:password@cache.corp.example.com

User info format is specified in RFC3986 https://datatracker.ietf.org/doc/html/rfc3986#section-3.2.1
Results in "Proxy-Authentication" behavior specified in rfc9110 https://datatracker.ietf.org/doc/html/rfc9110#section-11.7.2 

Fixes https://github.com/golang/go/issues/61505