### PR TITLE
github.com/gorilla/websocket has been active again

### DIFF
--- a/websocket/websocket.go
+++ b/websocket/websocket.go
@@ -5,10 +5,11 @@
 // Package websocket implements a client and server for the WebSocket protocol
 // as specified in RFC 6455.
 //
-// This package currently lacks some features found in an alternative
-// and more actively maintained WebSocket package:
+// This package currently lacks some features found in alternative
+// and more actively maintained WebSocket packages:
 //
 //	https://pkg.go.dev/nhooyr.io/websocket
+//	https://pkg.go.dev/github.com/gorilla/websocket
 package websocket // import "golang.org/x/net/websocket"
 
 import (


### PR DESCRIPTION
gorilla's websocket package is removed from recommendation at https://github.com/golang/net/commit/ad92d3db360ba0127e5d4d17cc94b2bb4c09e168.

When the recommendation was removed, Gorilla project didn't have any active maintainers and was inacitve, but the project got new maintainers and returned active at 2023 July.

It is still the most popular WebSocket's implementation (more than 20,000 packages use it) and much bigger than other packages. I think it should be recommended package again.