### PR TITLE
html: fix SOLIDUS '/' handling in attribute parsing

### DIFF
--- a/html/token_test.go
+++ b/html/token_test.go
@@ -601,6 +601,21 @@ var tokenTests = []tokenTest{
 		`<p  =asd>`,
 		`<p =asd="">`,
 	},
+	{
+		"forward slash before attribute name",
+		`<p/=">`,
+		`<p ="="">`,
+	},
+	{
+		"forward slash before attribute name with spaces around",
+		`<p / =">`,
+		`<p ="="">`,
+	},
+	{
+		"forward slash after attribute name followed by a character",
+		`<p a/ ="">`,
+		`<p a="" =""="">`,
+	},
 }
 
 func TestTokenizer(t *testing.T) {


### PR DESCRIPTION
Calling the Tokenizer with HTML elements containing SOLIDUS (/) character 
in the attribute name results in incorrect tokenization.

This is due to violation of the following rule transitions in the WHATWG spec:
- https://html.spec.whatwg.org/multipage/parsing.html#attribute-name-state, 
  where we are not reconsuming the character if '/' is encountered
- https://html.spec.whatwg.org/multipage/parsing.html#after-attribute-name-state, 
  where we are not switching to self closing state

Fixes golang/go#63402