### PR TITLE
http2: fix underflow in http2 server push

### DIFF
--- a/http2/server.go
+++ b/http2/server.go
@@ -3187,6 +3187,7 @@ func (sc *serverConn) startPush(msg *startPushRequest) {
 			panic(fmt.Sprintf("newWriterAndRequestNoBody(%+v): %v", msg.url, err))
 		}
 
+		sc.curHandlers++
 		go sc.runHandler(rw, req, sc.handler.ServeHTTP)
 		return promisedID, nil
 	}


### PR DESCRIPTION
After CL 534215 was merged to fix a CVE it introduced
an underflow when we try to decrement sc.curHandlers
in handlerDone.

The func startPush calls runHandler without incrementing
curHandlers. Seems to only affect users of http.Pusher.

For golang/go#63511