### PR TITLE
dns/dnsmessage: allow name compression for SRV resource parsing

### DIFF
--- a/dns/dnsmessage/message.go
+++ b/dns/dnsmessage/message.go
@@ -273,7 +273,6 @@ var (
 	errTooManyAdditionals = errors.New("too many Additionals to pack (>65535)")
 	errNonCanonicalName   = errors.New("name is not in canonical format (it must end with a .)")
 	errStringTooLong      = errors.New("character string exceeds maximum length (255)")
-	errCompressedSRV      = errors.New("compressed name in SRV resource data")
 )
 
 // Internal constants.
@@ -2028,10 +2027,10 @@ func (n *Name) pack(msg []byte, compression map[string]uint16, compressionOff in
 
 // unpack unpacks a domain name.
 func (n *Name) unpack(msg []byte, off int) (int, error) {
-	return n.unpackCompressed(msg, off, true /* allowCompression */)
+	return n.unpackCompressed(msg, off)
 }
 
-func (n *Name) unpackCompressed(msg []byte, off int, allowCompression bool) (int, error) {
+func (n *Name) unpackCompressed(msg []byte, off int) (int, error) {
 	// currOff is the current working offset.
 	currOff := off
 
@@ -2076,9 +2075,6 @@ Loop:
 			name = append(name, '.')
 			currOff = endOff
 		case 0xC0: // Pointer
-			if !allowCompression {
-				return off, errCompressedSRV
-			}
 			if currOff >= len(msg) {
 				return off, errInvalidPtr
 			}
@@ -2549,7 +2545,7 @@ func unpackSRVResource(msg []byte, off int) (SRVResource, error) {
 		return SRVResource{}, &nestedError{"Port", err}
 	}
 	var target Name
-	if _, err := target.unpackCompressed(msg, off, false /* allowCompression */); err != nil {
+	if _, err := target.unpackCompressed(msg, off); err != nil {
 		return SRVResource{}, &nestedError{"Target", err}
 	}
 	return SRVResource{priority, weight, port, target}, nil

--- a/dns/dnsmessage/message.go
+++ b/dns/dnsmessage/message.go
@@ -2027,10 +2027,6 @@ func (n *Name) pack(msg []byte, compression map[string]uint16, compressionOff in
 
 // unpack unpacks a domain name.
 func (n *Name) unpack(msg []byte, off int) (int, error) {
-	return n.unpackCompressed(msg, off)
-}
-
-func (n *Name) unpackCompressed(msg []byte, off int) (int, error) {
 	// currOff is the current working offset.
 	currOff := off
 
@@ -2545,7 +2541,7 @@ func unpackSRVResource(msg []byte, off int) (SRVResource, error) {
 		return SRVResource{}, &nestedError{"Port", err}
 	}
 	var target Name
-	if _, err := target.unpackCompressed(msg, off); err != nil {
+	if _, err := target.unpack(msg, off); err != nil {
 		return SRVResource{}, &nestedError{"Target", err}
 	}
 	return SRVResource{priority, weight, port, target}, nil

--- a/dns/dnsmessage/message_test.go
+++ b/dns/dnsmessage/message_test.go
@@ -303,28 +303,6 @@ func TestNameUnpackTooLongName(t *testing.T) {
 	}
 }
 
-func TestIncompressibleName(t *testing.T) {
-	name := MustNewName("example.com.")
-	compression := map[string]uint16{}
-	buf, err := name.pack(make([]byte, 0, 100), compression, 0)
-	if err != nil {
-		t.Fatal("first Name.pack() =", err)
-	}
-	buf, err = name.pack(buf, compression, 0)
-	if err != nil {
-		t.Fatal("second Name.pack() =", err)
-	}
-	var n1 Name
-	off, err := n1.unpackCompressed(buf, 0, false /* allowCompression */)
-	if err != nil {
-		t.Fatal("unpacking incompressible name without pointers failed:", err)
-	}
-	var n2 Name
-	if _, err := n2.unpackCompressed(buf, off, false /* allowCompression */); err != errCompressedSRV {
-		t.Errorf("unpacking compressed incompressible name with pointers: got %v, want = %v", err, errCompressedSRV)
-	}
-}
-
 func checkErrorPrefix(err error, prefix string) bool {
 	e, ok := err.(*nestedError)
 	return ok && e.s == prefix


### PR DESCRIPTION
As per RFC 3597:

Receiving servers MUST decompress domain names in RRs of well-known
   type, and SHOULD also decompress RRs of type RP, AFSDB, RT, SIG, PX,
   NXT, NAPTR, and SRV (although the current specification of the SRV RR
   in RFC2782 prohibits compression, RFC2052 mandated it, and some
   servers following that earlier specification are still in use).

This change allows SRV resource decompression.

Updates golang/go#36718
Updates golang/go#37362