### PR TITLE
http/httpguts: speed up ValidHeaderFieldName

### DIFF
--- a/http/httpguts/httplex.go
+++ b/http/httpguts/httplex.go
@@ -12,7 +12,7 @@ import (
 	"golang.org/x/net/idna"
 )
 
-var isTokenTable = [127]bool{
+var isTokenTable = [256]bool{
 	'!':  true,
 	'#':  true,
 	'$':  true,
@@ -93,8 +93,7 @@ var isTokenTable = [127]bool{
 }
 
 func IsTokenRune(r rune) bool {
-	i := int(r)
-	return i < len(isTokenTable) && isTokenTable[i]
+	return r < utf8.RuneSelf && isTokenTable[byte(r)]
 }
 
 // HeaderValuesContainsToken reports whether any string in values

--- a/http/httpguts/httplex.go
+++ b/http/httpguts/httplex.go
@@ -197,8 +197,8 @@ func ValidHeaderFieldName(v string) bool {
 	if len(v) == 0 {
 		return false
 	}
-	for _, r := range v {
-		if !IsTokenRune(r) {
+	for i := 0; i < len(v); i++ {
+		if !isTokenTable[v[i]] {
 			return false
 		}
 	}

--- a/http/httpguts/httplex.go
+++ b/http/httpguts/httplex.go
@@ -97,10 +97,6 @@ func IsTokenRune(r rune) bool {
 	return i < len(isTokenTable) && isTokenTable[i]
 }
 
-func isNotToken(r rune) bool {
-	return !IsTokenRune(r)
-}
-
 // HeaderValuesContainsToken reports whether any string in values
 // contains the provided token, ASCII case-insensitively.
 func HeaderValuesContainsToken(values []string, token string) bool {

--- a/http/httpguts/httplex_test.go
+++ b/http/httpguts/httplex_test.go
@@ -109,6 +109,44 @@ func TestHeaderValuesContainsToken(t *testing.T) {
 	}
 }
 
+func TestValidHeaderFieldName(t *testing.T) {
+	tests := []struct {
+		in   string
+		want bool
+	}{
+		{"", false},
+		{"Accept Charset", false},
+		{"Accept-Charset", true},
+		{"AccepT-EncodinG", true},
+		{"CONNECTION", true},
+		{"résumé", false},
+	}
+	for _, tt := range tests {
+		got := ValidHeaderFieldName(tt.in)
+		if tt.want != got {
+			t.Errorf("ValidHeaderFieldName(%q) = %t; want %t", tt.in, got, tt.want)
+		}
+	}
+}
+
+func BenchmarkValidHeaderFieldName(b *testing.B) {
+	names := []string{
+		"",
+		"Accept Charset",
+		"Accept-Charset",
+		"AccepT-EncodinG",
+		"CONNECTION",
+		"résumé",
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for _, name := range names {
+			ValidHeaderFieldName(name)
+		}
+	}
+}
+
 func TestPunycodeHostPort(t *testing.T) {
 	tests := []struct {
 		in, want string

--- a/http/httpguts/httplex_test.go
+++ b/http/httpguts/httplex_test.go
@@ -20,7 +20,7 @@ func isSeparator(c rune) bool {
 	return false
 }
 
-func TestIsToken(t *testing.T) {
+func TestIsTokenRune(t *testing.T) {
 	for i := 0; i <= 130; i++ {
 		r := rune(i)
 		expected := isChar(r) && !isCtl(r) && !isSeparator(r)

--- a/http/httpguts/httplex_test.go
+++ b/http/httpguts/httplex_test.go
@@ -30,6 +30,15 @@ func TestIsTokenRune(t *testing.T) {
 	}
 }
 
+func BenchmarkIsTokenRune(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		var r rune
+		for ; r < 1024; r++ {
+			IsTokenRune(r)
+		}
+	}
+}
+
 func TestHeaderValuesContainsToken(t *testing.T) {
 	tests := []struct {
 		vals  []string


### PR DESCRIPTION
Eliminate bounds checks and eschews UTF-8 decoding in ValidHeaderFieldName,
thereby doubling its speed without introducing any allocations.
Also eliminate bounds checks in IsTokenRune.

Add tests and benchmarks for both ValidHeaderFieldName and IsTokenRune.

goos: darwin
goarch: amd64
pkg: golang.org/x/net/http/httpguts
cpu: Intel(R) Core(TM) i7-6700HQ CPU @ 2.60GHz
                       │   before    │                after                │
                       │   sec/op    │   sec/op     vs base                │
IsTokenRune-8            315.2n ± 0%   316.2n ± 1%        ~ (p=0.245 n=20)
ValidHeaderFieldName-8   62.77n ± 0%   29.16n ± 0%  -53.55% (p=0.000 n=20)
geomean                  140.7n        96.02n       -31.73%

                       │    before    │                after               │
                       │     B/op     │    B/op     vs base                │
IsTokenRune-8            0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=20)
ValidHeaderFieldName-8   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=20)
geomean                             ²               +0.00%

                       │    before    │                after               │
                       │  allocs/op   │ allocs/op   vs base                │
IsTokenRune-8            0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=20)
ValidHeaderFieldName-8   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=20)
geomean                             ²               +0.00%

Fixes golang/go#66700
