### PR TITLE
x/net/html: add Node.{Ancestors,ChildNodes,Descendants}()

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module golang.org/x/net
 
-go 1.23
+go 1.18
 
 require (
 	golang.org/x/crypto v0.28.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module golang.org/x/net
 
-go 1.18
+go 1.22
 
 require (
 	golang.org/x/crypto v0.28.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module golang.org/x/net
 
-go 1.22
+go 1.23
 
 require (
 	golang.org/x/crypto v0.28.0

--- a/html/doc.go
+++ b/html/doc.go
@@ -78,16 +78,11 @@ example, to process each anchor node in depth-first order:
 	if err != nil {
 		// ...
 	}
-	var f func(*html.Node)
-	f = func(n *html.Node) {
+	for n := range doc.All() {
 		if n.Type == html.ElementNode && n.Data == "a" {
 			// Do something with n...
 		}
-		for c := n.FirstChild; c != nil; c = c.NextSibling {
-			f(c)
-		}
 	}
-	f(doc)
 
 The relevant specifications include:
 https://html.spec.whatwg.org/multipage/syntax.html and

--- a/html/doc.go
+++ b/html/doc.go
@@ -78,7 +78,7 @@ example, to process each anchor node in depth-first order:
 	if err != nil {
 		// ...
 	}
-	for n := range doc.All() {
+	for n := range doc.Descendants() {
 		if n.Type == html.ElementNode && n.Data == "a" {
 			// Do something with n...
 		}

--- a/html/example_test.go
+++ b/html/example_test.go
@@ -22,7 +22,7 @@ func ExampleParse() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	for n := range doc.All() {
+	for n := range doc.Descendants() {
 		if n.Type == html.ElementNode && n.DataAtom == atom.A {
 			for _, a := range n.Attr {
 				if a.Key == "href" {

--- a/html/example_test.go
+++ b/html/example_test.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	"golang.org/x/net/html"
+	"golang.org/x/net/html/atom"
 )
 
 func ExampleParse() {
@@ -22,7 +23,7 @@ func ExampleParse() {
 		log.Fatal(err)
 	}
 	for n := range doc.All() {
-		if n.Type == html.ElementNode && n.Data == "a" {
+		if n.Type == html.ElementNode && n.DataAtom == atom.A {
 			for _, a := range n.Attr {
 				if a.Key == "href" {
 					fmt.Println(a.Val)

--- a/html/example_test.go
+++ b/html/example_test.go
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build goexperiment.rangefunc
+
 // This example demonstrates parsing HTML data and walking the resulting tree.
 package html_test
 
@@ -19,8 +21,7 @@ func ExampleParse() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	var f func(*html.Node)
-	f = func(n *html.Node) {
+	for n := range doc.All() {
 		if n.Type == html.ElementNode && n.Data == "a" {
 			for _, a := range n.Attr {
 				if a.Key == "href" {
@@ -29,11 +30,8 @@ func ExampleParse() {
 				}
 			}
 		}
-		for c := n.FirstChild; c != nil; c = c.NextSibling {
-			f(c)
-		}
 	}
-	f(doc)
+
 	// Output:
 	// foo
 	// /bar/baz

--- a/html/example_test.go
+++ b/html/example_test.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build goexperiment.rangefunc
+//go:build go1.23
 
 // This example demonstrates parsing HTML data and walking the resulting tree.
 package html_test

--- a/html/iter.go
+++ b/html/iter.go
@@ -8,9 +8,22 @@ package html
 
 import "iter"
 
+// Parents returns an sequence yielding the node and its parents.
+//
+// Mutating a Node or its parents while iterating may have unexpected results.
+func (n *Node) Parents() iter.Seq[*Node] {
+	return func(yield func(*Node) bool) {
+		for p := n; p != nil; p = p.Parent {
+			if !yield(p) {
+				return
+			}
+		}
+	}
+}
+
 // ChildNodes returns a sequence yielding the immediate children of n.
 //
-// Mutating a Node while iterating through its ChildNodes may have unexpected results.
+// Mutating a Node or its ChildNodes while iterating may have unexpected results.
 func (n *Node) ChildNodes() iter.Seq[*Node] {
 	return func(yield func(*Node) bool) {
 		if n == nil {
@@ -25,6 +38,18 @@ func (n *Node) ChildNodes() iter.Seq[*Node] {
 
 }
 
+// All returns a sequence yielding all descendents of n in depth-first pre-order.
+//
+// Mutating a Node or its descendents while iterating may have unexpected results.
+func (n *Node) All() iter.Seq[*Node] {
+	return func(yield func(*Node) bool) {
+		if n == nil {
+			return
+		}
+		n.all(yield)
+	}
+}
+
 func (n *Node) all(yield func(*Node) bool) bool {
 	if !yield(n) {
 		return false
@@ -36,29 +61,4 @@ func (n *Node) all(yield func(*Node) bool) bool {
 		}
 	}
 	return true
-}
-
-// All returns a sequence yielding all descendents of n in depth-first pre-order.
-//
-// Mutating a Node while iterating through it or its descendents may have unexpected results.
-func (n *Node) All() iter.Seq[*Node] {
-	return func(yield func(*Node) bool) {
-		if n == nil {
-			return
-		}
-		n.all(yield)
-	}
-}
-
-// Parents returns an sequence yielding the node and its parents.
-//
-// Mutating a Node while iterating through it or its parents may have unexpected results.
-func (n *Node) Parents() iter.Seq[*Node] {
-	return func(yield func(*Node) bool) {
-		for p := n; p != nil; p = p.Parent {
-			if !yield(p) {
-				return
-			}
-		}
-	}
 }

--- a/html/iter.go
+++ b/html/iter.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build goexperiment.rangefunc
+//go:build go1.23
 
 package html
 

--- a/html/iter.go
+++ b/html/iter.go
@@ -30,6 +30,8 @@ func (n *Node) Ancestors() iter.Seq[*Node] {
 // Example:
 //
 //	for child := range n.Children() { ... }
+//
+// Mutating a Node or its children while iterating may have unexpected results.
 func (n *Node) Children() iter.Seq[*Node] {
 	_ = n.FirstChild // eager nil check
 
@@ -46,6 +48,8 @@ func (n *Node) Children() iter.Seq[*Node] {
 // Example:
 //
 //	for desc := range n.Descendants() { ... }
+//
+// Mutating a Node or its descendants while iterating may have unexpected results.
 func (n *Node) Descendants() iter.Seq[*Node] {
 	_ = n.FirstChild // eager nil check
 

--- a/html/iter.go
+++ b/html/iter.go
@@ -49,3 +49,14 @@ func (n *Node) All() iter.Seq[*Node] {
 		n.all(yield)
 	}
 }
+
+// Parents returns an sequence yielding the node and its parents.
+func (n *Node) Parents() iter.Seq[*Node] {
+	return func(yield func(*Node) bool) {
+		for p := n; p != nil; p = p.Parent {
+			if !yield(p) {
+				return
+			}
+		}
+	}
+}

--- a/html/iter.go
+++ b/html/iter.go
@@ -24,15 +24,15 @@ func (n *Node) Ancestors() iter.Seq[*Node] {
 	}
 }
 
-// Children returns an iterator over the immediate children of n,
+// ChildNodes returns an iterator over the immediate children of n,
 // starting with n.FirstChild.
 //
 // Example:
 //
-//	for child := range n.Children() { ... }
+//	for child := range n.ChildNodes() { ... }
 //
 // Mutating a Node or its children while iterating may have unexpected results.
-func (n *Node) Children() iter.Seq[*Node] {
+func (n *Node) ChildNodes() iter.Seq[*Node] {
 	_ = n.FirstChild // eager nil check
 
 	return func(yield func(*Node) bool) {
@@ -59,7 +59,7 @@ func (n *Node) Descendants() iter.Seq[*Node] {
 }
 
 func (n *Node) descendants(yield func(*Node) bool) bool {
-	for c := range n.Children() {
+	for c := range n.ChildNodes() {
 		if !yield(c) || !c.descendants(yield) {
 			return false
 		}

--- a/html/iter.go
+++ b/html/iter.go
@@ -26,9 +26,6 @@ func (n *Node) ChildNodes() iter.Seq[*Node] {
 }
 
 func (n *Node) all(yield func(*Node) bool) bool {
-	if n == nil {
-		return true
-	}
 	if !yield(n) {
 		return false
 	}
@@ -46,6 +43,9 @@ func (n *Node) all(yield func(*Node) bool) bool {
 // Mutating a Node while iterating through it or its descendents may have unexpected results.
 func (n *Node) All() iter.Seq[*Node] {
 	return func(yield func(*Node) bool) {
+		if n == nil {
+			return
+		}
 		n.all(yield)
 	}
 }

--- a/html/iter.go
+++ b/html/iter.go
@@ -10,10 +10,6 @@ import "iter"
 
 // Ancestors returns an iterator over the ancestors of n, starting with n.Parent.
 //
-// Example:
-//
-//	for ancestor := range n.Ancestors() { ... }
-//
 // Mutating a Node or its parents while iterating may have unexpected results.
 func (n *Node) Ancestors() iter.Seq[*Node] {
 	_ = n.Parent // eager nil check
@@ -26,10 +22,6 @@ func (n *Node) Ancestors() iter.Seq[*Node] {
 
 // ChildNodes returns an iterator over the immediate children of n,
 // starting with n.FirstChild.
-//
-// Example:
-//
-//	for child := range n.ChildNodes() { ... }
 //
 // Mutating a Node or its children while iterating may have unexpected results.
 func (n *Node) ChildNodes() iter.Seq[*Node] {
@@ -45,16 +37,12 @@ func (n *Node) ChildNodes() iter.Seq[*Node] {
 // Descendants returns an iterator over all nodes recursively beneath
 // n, excluding n itself. Nodes are visited in depth-first preorder.
 //
-// Example:
-//
-//	for desc := range n.Descendants() { ... }
-//
 // Mutating a Node or its descendants while iterating may have unexpected results.
 func (n *Node) Descendants() iter.Seq[*Node] {
 	_ = n.FirstChild // eager nil check
 
 	return func(yield func(*Node) bool) {
-		_ = n.descendants(yield)
+		n.descendants(yield)
 	}
 }
 

--- a/html/iter.go
+++ b/html/iter.go
@@ -51,6 +51,8 @@ func (n *Node) All() iter.Seq[*Node] {
 }
 
 // Parents returns an sequence yielding the node and its parents.
+//
+// Mutating a Node while iterating through it or its parents may have unexpected results.
 func (n *Node) Parents() iter.Seq[*Node] {
 	return func(yield func(*Node) bool) {
 		for p := n; p != nil; p = p.Parent {

--- a/html/iter.go
+++ b/html/iter.go
@@ -1,0 +1,51 @@
+// Copyright 2024 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build goexperiment.rangefunc
+
+package html
+
+import "iter"
+
+// ChildNodes returns a sequence yielding the immediate children of n.
+//
+// Mutating a Node while iterating through its ChildNodes may have unexpected results.
+func (n *Node) ChildNodes() iter.Seq[*Node] {
+	return func(yield func(*Node) bool) {
+		if n == nil {
+			return
+		}
+		for c := n.FirstChild; c != nil; c = c.NextSibling {
+			if !yield(c) {
+				return
+			}
+		}
+	}
+
+}
+
+func (n *Node) all(yield func(*Node) bool) bool {
+	if n == nil {
+		return true
+	}
+	if !yield(n) {
+		return false
+	}
+
+	for c := range n.ChildNodes() {
+		if !c.all(yield) {
+			return false
+		}
+	}
+	return true
+}
+
+// All returns a sequence yielding all descendents of n in depth-first pre-order.
+//
+// Mutating a Node while iterating through it or its descendents may have unexpected results.
+func (n *Node) All() iter.Seq[*Node] {
+	return func(yield func(*Node) bool) {
+		n.all(yield)
+	}
+}

--- a/html/iter_test.go
+++ b/html/iter_test.go
@@ -83,14 +83,13 @@ func TestNode_Parents(t *testing.T) {
 }
 
 func buildChain(size int) *Node {
-	descendent := new(Node)
-	current := descendent
+	child := new(Node)
 	for range size {
-		parent := new(Node)
-		parent.AppendChild(current)
-		current = parent
+		parent := child
+		child = new(Node)
+		parent.AppendChild(child)
 	}
-	return descendent
+	return child
 }
 
 func testParents(t *testing.T, n *Node, wantSize int) {

--- a/html/iter_test.go
+++ b/html/iter_test.go
@@ -82,6 +82,17 @@ func TestNode_Parents(t *testing.T) {
 	}
 }
 
+func buildChain(size int) *Node {
+	descendent := new(Node)
+	current := descendent
+	for range size {
+		parent := new(Node)
+		parent.AppendChild(current)
+		current = parent
+	}
+	return descendent
+}
+
 func testParents(t *testing.T, n *Node, wantSize int) {
 	nParents := 0
 	for _ = range n.Parents() {
@@ -90,19 +101,4 @@ func testParents(t *testing.T, n *Node, wantSize int) {
 	if nParents != wantSize {
 		t.Errorf("unexpected number of Parents; want %d got: %d", wantSize, nParents)
 	}
-}
-
-func buildChain(size int) *Node {
-	descendent := &Node{
-		Type: ElementNode,
-	}
-	current := descendent
-	for range size {
-		parent := &Node{
-			Type: ElementNode,
-		}
-		parent.AppendChild(current)
-		current = parent
-	}
-	return descendent
 }

--- a/html/iter_test.go
+++ b/html/iter_test.go
@@ -36,7 +36,7 @@ func TestNode_ChildNodes(t *testing.T) {
 			results = append(results, c.Data)
 		}
 		if got := strings.Join(results, " "); got != test.want {
-			t.Errorf("unexpected children yielded by ChildNodes; want: %q got: %q", test.want, got)
+			t.Errorf("ChildNodes = %q, want %q", got, test.want)
 		}
 	}
 }
@@ -67,8 +67,7 @@ func TestNode_Descendants(t *testing.T) {
 			results = append(results, c.Data)
 		}
 		if got := strings.Join(results, " "); got != test.want {
-			t.Errorf("unexpected children yielded by Descendants; want: %q got: %q",
-				test.want, got)
+			t.Errorf("Descendants = %q; want: %q", got, test.want)
 		}
 	}
 }
@@ -81,7 +80,7 @@ func TestNode_Ancestors(t *testing.T) {
 			nParents++
 		}
 		if nParents != size {
-			t.Errorf("unexpected number of Ancestors; want %d got: %d", size, nParents)
+			t.Errorf("number of Ancestors = %d; want: %d", nParents, size)
 		}
 	}
 }

--- a/html/iter_test.go
+++ b/html/iter_test.go
@@ -1,0 +1,75 @@
+// Copyright 2024 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build goexperiment.rangefunc
+
+package html
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNode_ChildNodes(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"", ""},
+		{"<a></a>", ""},
+		{"<a><b></b></a>", "b"},
+		{"<a>b</a>", "b"},
+		{"<a><!--b--></a>", "b"},
+		{"<a>b<c></c>d</a>", "b c d"},
+		{"<a>b<c><!--d--></c>e</a>", "b c e"},
+		{"<a><b><c>d<!--e-->f</c></b>g<!--h--><i>j</i></a>", "b g h i"},
+	}
+	for _, test := range tests {
+		doc, err := Parse(strings.NewReader(test.in))
+		if err != nil {
+			t.Fatal(err)
+		}
+		// Drill to <html><head></head><body> test.in
+		n := doc.FirstChild.FirstChild.NextSibling.FirstChild
+		var results []string
+		for c := range n.ChildNodes() {
+			results = append(results, c.Data)
+		}
+		if got := strings.Join(results, " "); got != test.want {
+			t.Errorf("unexpected children yielded by ChildNodes; want: %q got: %q", test.want, got)
+		}
+	}
+}
+
+func TestNode_All(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"", ""},
+		{"<a></a>", "a"},
+		{"<a><b></b></a>", "a b"},
+		{"<a>b</a>", "a b"},
+		{"<a><!--b--></a>", "a b"},
+		{"<a>b<c></c>d</a>", "a b c d"},
+		{"<a>b<c><!--d--></c>e</a>", "a b c d e"},
+		{"<a><b><c>d<!--e-->f</c></b>g<!--h--><i>j</i></a>", "a b c d e f g h i j"},
+	}
+	for _, test := range tests {
+		doc, err := Parse(strings.NewReader(test.in))
+		if err != nil {
+			t.Fatal(err)
+		}
+		// Drill to <html><head></head><body> test.in
+		n := doc.FirstChild.FirstChild.NextSibling.FirstChild
+		var results []string
+		for c := range n.All() {
+			results = append(results, c.Data)
+		}
+		if got := strings.Join(results, " "); got != test.want {
+			t.Errorf("unexpected children yielded by All; want: %q got: %q",
+				test.want, got)
+		}
+	}
+}

--- a/html/iter_test.go
+++ b/html/iter_test.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build goexperiment.rangefunc
+//go:build go1.23
 
 package html
 

--- a/html/iter_test.go
+++ b/html/iter_test.go
@@ -73,3 +73,36 @@ func TestNode_All(t *testing.T) {
 		}
 	}
 }
+
+func TestNode_Parents(t *testing.T) {
+	testParents(t, nil, 0)
+	for size := range 100 {
+		n := buildChain(size)
+		testParents(t, n, size+1)
+	}
+}
+
+func testParents(t *testing.T, n *Node, wantSize int) {
+	nParents := 0
+	for _ = range n.Parents() {
+		nParents++
+	}
+	if nParents != wantSize {
+		t.Errorf("unexpected number of Parents; want %d got: %d", wantSize, nParents)
+	}
+}
+
+func buildChain(size int) *Node {
+	descendent := &Node{
+		Type: ElementNode,
+	}
+	current := descendent
+	for range size {
+		parent := &Node{
+			Type: ElementNode,
+		}
+		parent.AppendChild(current)
+		current = parent
+	}
+	return descendent
+}

--- a/html/iter_test.go
+++ b/html/iter_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 )
 
-func TestNode_Children(t *testing.T) {
+func TestNode_ChildNodes(t *testing.T) {
 	tests := []struct {
 		in   string
 		want string
@@ -32,11 +32,11 @@ func TestNode_Children(t *testing.T) {
 		// Drill to <html><head></head><body>
 		n := doc.FirstChild.FirstChild.NextSibling
 		var results []string
-		for c := range n.Children() {
+		for c := range n.ChildNodes() {
 			results = append(results, c.Data)
 		}
 		if got := strings.Join(results, " "); got != test.want {
-			t.Errorf("unexpected children yielded by Children; want: %q got: %q", test.want, got)
+			t.Errorf("unexpected children yielded by ChildNodes; want: %q got: %q", test.want, got)
 		}
 	}
 }

--- a/html/iter_test.go
+++ b/html/iter_test.go
@@ -16,21 +16,21 @@ func TestNode_Children(t *testing.T) {
 		in   string
 		want string
 	}{
-		{"<a></a>", ""},
-		{"<a><b></b></a>", "b"},
-		{"<a>b</a>", "b"},
-		{"<a><!--b--></a>", "b"},
-		{"<a>b<c></c>d</a>", "b c d"},
-		{"<a>b<c><!--d--></c>e</a>", "b c e"},
-		{"<a><b><c>d<!--e-->f</c></b>g<!--h--><i>j</i></a>", "b g h i"},
+		{"", ""},
+		{"<a></a>", "a"},
+		{"a", "a"},
+		{"<a></a><!--b-->", "a b"},
+		{"a<b></b>c", "a b c"},
+		{"a<b><!--c--></b>d", "a b d"},
+		{"<a><b>c<!--d-->e</b></a>f<!--g--><h>i</h>", "a f g h"},
 	}
 	for _, test := range tests {
 		doc, err := Parse(strings.NewReader(test.in))
 		if err != nil {
 			t.Fatal(err)
 		}
-		// Drill to <html><head></head><body><a>
-		n := doc.FirstChild.FirstChild.NextSibling.FirstChild
+		// Drill to <html><head></head><body>
+		n := doc.FirstChild.FirstChild.NextSibling
 		var results []string
 		for c := range n.Children() {
 			results = append(results, c.Data)

--- a/html/iter_test.go
+++ b/html/iter_test.go
@@ -11,12 +11,11 @@ import (
 	"testing"
 )
 
-func TestNode_ChildNodes(t *testing.T) {
+func TestNode_Children(t *testing.T) {
 	tests := []struct {
 		in   string
 		want string
 	}{
-		{"", ""},
 		{"<a></a>", ""},
 		{"<a><b></b></a>", "b"},
 		{"<a>b</a>", "b"},
@@ -30,19 +29,19 @@ func TestNode_ChildNodes(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		// Drill to <html><head></head><body> test.in
+		// Drill to <html><head></head><body><a>
 		n := doc.FirstChild.FirstChild.NextSibling.FirstChild
 		var results []string
-		for c := range n.ChildNodes() {
+		for c := range n.Children() {
 			results = append(results, c.Data)
 		}
 		if got := strings.Join(results, " "); got != test.want {
-			t.Errorf("unexpected children yielded by ChildNodes; want: %q got: %q", test.want, got)
+			t.Errorf("unexpected children yielded by Children; want: %q got: %q", test.want, got)
 		}
 	}
 }
 
-func TestNode_All(t *testing.T) {
+func TestNode_Descendants(t *testing.T) {
 	tests := []struct {
 		in   string
 		want string
@@ -61,24 +60,29 @@ func TestNode_All(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		// Drill to <html><head></head><body> test.in
-		n := doc.FirstChild.FirstChild.NextSibling.FirstChild
+		// Drill to <html><head></head><body>
+		n := doc.FirstChild.FirstChild.NextSibling
 		var results []string
-		for c := range n.All() {
+		for c := range n.Descendants() {
 			results = append(results, c.Data)
 		}
 		if got := strings.Join(results, " "); got != test.want {
-			t.Errorf("unexpected children yielded by All; want: %q got: %q",
+			t.Errorf("unexpected children yielded by Descendants; want: %q got: %q",
 				test.want, got)
 		}
 	}
 }
 
-func TestNode_Parents(t *testing.T) {
-	testParents(t, nil, 0)
-	for size := range 100 {
+func TestNode_Ancestors(t *testing.T) {
+	for _, size := range []int{0, 1, 2, 10, 100, 10_000} {
 		n := buildChain(size)
-		testParents(t, n, size+1)
+		nParents := 0
+		for _ = range n.Ancestors() {
+			nParents++
+		}
+		if nParents != size {
+			t.Errorf("unexpected number of Ancestors; want %d got: %d", size, nParents)
+		}
 	}
 }
 
@@ -90,14 +94,4 @@ func buildChain(size int) *Node {
 		parent.AppendChild(child)
 	}
 	return child
-}
-
-func testParents(t *testing.T, n *Node, wantSize int) {
-	nParents := 0
-	for _ = range n.Parents() {
-		nParents++
-	}
-	if nParents != wantSize {
-		t.Errorf("unexpected number of Parents; want %d got: %d", wantSize, nParents)
-	}
 }

--- a/html/node.go
+++ b/html/node.go
@@ -38,6 +38,10 @@ var scopeMarker = Node{Type: scopeMarkerNode}
 // that it looks like "a<b" rather than "a&lt;b". For element nodes, DataAtom
 // is the atom for Data, or zero if Data is not a known tag name.
 //
+// Node trees may be navigated using the link fields (Parent,
+// FirstChild, and so on) or a range loop over iterators such as
+// [Node.Descendants].
+//
 // An empty Namespace implies a "http://www.w3.org/1999/xhtml" namespace.
 // Similarly, "math" is short for "http://www.w3.org/1998/Math/MathML", and
 // "svg" is short for "http://www.w3.org/2000/svg".


### PR DESCRIPTION
Adds iterators for the parents, immediate children, and all children of a Node respectively.

Fixes golang/go#62113