### PR TITLE
websocket: update nhooyr.io/websocket to github.com/coder/websocket

### DIFF
--- a/websocket/websocket.go
+++ b/websocket/websocket.go
@@ -8,7 +8,7 @@
 // This package currently lacks some features found in an alternative
 // and more actively maintained WebSocket package:
 //
-//	https://pkg.go.dev/nhooyr.io/websocket
+//	https://pkg.go.dev/github.com/coder/websocket
 package websocket // import "golang.org/x/net/websocket"
 
 import (


### PR DESCRIPTION
Maintenance of nhooyr.io/websocket has moved to github.com/coder/websocket.

Read more about the transition at https://coder.com/blog/websocket

Updates golang/go#18152