### PR TITLE
http2: improve error when server sends HTTP/1

### DIFF
--- a/http2/frame_test.go
+++ b/http2/frame_test.go
@@ -626,6 +626,27 @@ func TestReadFrameHeader(t *testing.T) {
 	}
 }
 
+func TestReadFrameHeader_FromHTTP1Header(t *testing.T) {
+	tests := []struct {
+		in             string
+		looksLikeHTTP1 bool
+	}{
+		// Ignore high bit:
+		{in: "\xff\xff\xff" + "\xff" + "\xff" + "\xff\xff\xff\xff", looksLikeHTTP1: false},
+		{in: "HTTP/1.1 400 Bad Request\r\n", looksLikeHTTP1: true},
+	}
+	for i, tt := range tests {
+		got, err := readFrameHeader(make([]byte, 9), strings.NewReader(tt.in))
+		if err != nil {
+			t.Errorf("%d. readFrameHeader(%q) = %v", i, tt.in, err)
+			continue
+		}
+		if got.looksLikeHTTP1Header() != tt.looksLikeHTTP1 {
+			t.Errorf("%d. readFrameHeader(%q).looksLikeHTTP1Header = %v; want %v", i, tt.in, got.looksLikeHTTP1Header(), tt.looksLikeHTTP1)
+		}
+	}
+}
+
 func TestReadWriteFrameHeader(t *testing.T) {
 	tests := []struct {
 		len      uint32

--- a/http2/frame_test.go
+++ b/http2/frame_test.go
@@ -626,27 +626,6 @@ func TestReadFrameHeader(t *testing.T) {
 	}
 }
 
-func TestReadFrameHeader_FromHTTP1Header(t *testing.T) {
-	tests := []struct {
-		in             string
-		looksLikeHTTP1 bool
-	}{
-		// Ignore high bit:
-		{in: "\xff\xff\xff" + "\xff" + "\xff" + "\xff\xff\xff\xff", looksLikeHTTP1: false},
-		{in: "HTTP/1.1 400 Bad Request\r\n", looksLikeHTTP1: true},
-	}
-	for i, tt := range tests {
-		got, err := readFrameHeader(make([]byte, 9), strings.NewReader(tt.in))
-		if err != nil {
-			t.Errorf("%d. readFrameHeader(%q) = %v", i, tt.in, err)
-			continue
-		}
-		if got.looksLikeHTTP1Header() != tt.looksLikeHTTP1 {
-			t.Errorf("%d. readFrameHeader(%q).looksLikeHTTP1Header = %v; want %v", i, tt.in, got.looksLikeHTTP1Header(), tt.looksLikeHTTP1)
-		}
-	}
-}
-
 func TestReadWriteFrameHeader(t *testing.T) {
 	tests := []struct {
 		len      uint32

--- a/http2/transport_test.go
+++ b/http2/transport_test.go
@@ -289,7 +289,7 @@ func TestTransportFailureErrorForHTTP1Response(t *testing.T) {
 		},
 		{
 			name:         "with enough frame size to start reading",
-			maxFrameSize: invalidHTTP1LookingFrameHeader.Length + 1,
+			maxFrameSize: invalidHTTP1LookingFrameHeader().Length + 1,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
If for some reason the server sends an HTTP/1.1 response
starting with "HTTP/1.1 " (9 bytes), http2 transport interprets that as
a valid frame header for an expected payload of ~4MB, and fails with
non-descriptive messages like "unexpected EOF".

This could happen, for example, if ALPN is misconfigured on the server's
load balancer.

This change attempts to improve that feedback by noting in the error
messages whenever the frame header was exactly the "HTTP/1.1 " bytes.