### PR TITLE
http2: improve handling of lost PING in Server

### DIFF
--- a/http2/server.go
+++ b/http2/server.go
@@ -1069,6 +1069,9 @@ func (sc *serverConn) serve(conf http2Config) {
 func (sc *serverConn) handlePingTimer(lastFrameReadTime time.Time) {
 	if sc.pingSent {
 		sc.logf("timeout waiting for PING response")
+		if f := sc.countErrorFunc; f != nil {
+			f("conn_close_lost_ping")
+		}
 		sc.conn.Close()
 		return
 	}

--- a/http2/server.go
+++ b/http2/server.go
@@ -1068,7 +1068,7 @@ func (sc *serverConn) serve(conf http2Config) {
 
 func (sc *serverConn) handlePingTimer(lastFrameReadTime time.Time) {
 	if sc.pingSent {
-		sc.vlogf("timeout waiting for PING response")
+		sc.logf("timeout waiting for PING response")
 		sc.conn.Close()
 		return
 	}


### PR DESCRIPTION
This addresses inconsistencies in handling lost PINGs
between Server and Transport by:
1. Always logging a message for lost PINGs, regardless of verbose mode.
2. Invoking CountError with the conn_close_lost_ping error key.

Fixes golang/go#69963