### PR TITLE
Update timeseries.go: if num <= 0

### DIFF
--- a/internal/timeseries/timeseries.go
+++ b/internal/timeseries/timeseries.go
@@ -357,7 +357,7 @@ func (ts *timeSeries) ComputeRange(start, finish time.Time, num int) []Observabl
 		return nil
 	}
 
-	if num < 0 {
+	if num <= 0 {
 		log.Printf("timeseries: num < 0, %v", num)
 		return nil
 	}


### PR DESCRIPTION
change condition because if num=0, than inside function ts.extract() will be division by zero (dstInterval := finish.Sub(start) / time.Duration(num)).