### PR TITLE
route: avoid parsing rt_msghdr2 fields as pid, seq, errno

### DIFF
--- a/route/message_darwin_test.go
+++ b/route/message_darwin_test.go
@@ -35,3 +35,67 @@ func TestFetchAndParseRIBOnDarwin(t *testing.T) {
 		}
 	}
 }
+
+func TestParseRIBOnDarwinRTMGET2DoesNotTreatUseAsErr(t *testing.T) {
+	b := makeRouteMessageBytes(syscall.RTM_GET2, sizeofRtMsghdr2Darwin15)
+	nativeEndian.PutUint32(b[16:20], 5)   // rtm_refcnt in rt_msghdr2, not rtm_pid.
+	nativeEndian.PutUint32(b[20:24], 800) // rtm_parentflags in rt_msghdr2, not rtm_seq.
+	nativeEndian.PutUint32(b[28:32], 140) // rtm_use in rt_msghdr2, not rtm_errno.
+
+	ms, err := ParseRIB(RIBType(syscall.NET_RT_DUMP2), b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ms) != 1 {
+		t.Fatalf("got %d messages; want 1", len(ms))
+	}
+	rm, ok := ms[0].(*RouteMessage)
+	if !ok {
+		t.Fatalf("got %T; want *RouteMessage", ms[0])
+	}
+	if rm.Err != nil {
+		t.Fatalf("got Err %v; want nil", rm.Err)
+	}
+	if rm.ID != 0 {
+		t.Fatalf("got ID %d; want 0", rm.ID)
+	}
+	if rm.Seq != 0 {
+		t.Fatalf("got Seq %d; want 0", rm.Seq)
+	}
+}
+
+func TestParseRIBOnDarwinRTMGETTreatsErrnoAsErr(t *testing.T) {
+	b := makeRouteMessageBytes(syscall.RTM_GET, sizeofRtMsghdrDarwin15)
+	nativeEndian.PutUint32(b[16:20], 1234)
+	nativeEndian.PutUint32(b[20:24], 5678)
+	nativeEndian.PutUint32(b[28:32], 140)
+
+	ms, err := ParseRIB(0, b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ms) != 1 {
+		t.Fatalf("got %d messages; want 1", len(ms))
+	}
+	rm, ok := ms[0].(*RouteMessage)
+	if !ok {
+		t.Fatalf("got %T; want *RouteMessage", ms[0])
+	}
+	if rm.Err == nil {
+		t.Fatal("got nil Err; want non-nil")
+	}
+	if rm.ID != 1234 {
+		t.Fatalf("got ID %d; want 1234", rm.ID)
+	}
+	if rm.Seq != 5678 {
+		t.Fatalf("got Seq %d; want 5678", rm.Seq)
+	}
+}
+
+func makeRouteMessageBytes(typ, size int) []byte {
+	b := make([]byte, size)
+	nativeEndian.PutUint16(b[:2], uint16(len(b)))
+	b[2] = rtmVersion
+	b[3] = byte(typ)
+	return b
+}

--- a/route/route_classic.go
+++ b/route/route_classic.go
@@ -57,14 +57,20 @@ func (w *wireFormat) parseRouteMessage(typ RIBType, b []byte) (Message, error) {
 		Type:    int(b[3]),
 		Flags:   int(nativeEndian.Uint32(b[8:12])),
 		Index:   int(nativeEndian.Uint16(b[4:6])),
-		ID:      uintptr(nativeEndian.Uint32(b[16:20])),
-		Seq:     int(nativeEndian.Uint32(b[20:24])),
 		extOff:  w.extOff,
 		raw:     b[:l],
 	}
-	errno := syscall.Errno(nativeEndian.Uint32(b[28:32]))
-	if errno != 0 {
-		m.Err = errno
+	if w.idOff > 0 {
+		m.ID = uintptr(nativeEndian.Uint32(b[w.idOff : w.idOff+4]))
+	}
+	if w.seqOff > 0 {
+		m.Seq = int(nativeEndian.Uint32(b[w.seqOff : w.seqOff+4]))
+	}
+	if w.errOff > 0 {
+		errno := syscall.Errno(nativeEndian.Uint32(b[w.errOff : w.errOff+4]))
+		if errno != 0 {
+			m.Err = errno
+		}
 	}
 	var err error
 	m.Addrs, err = parseAddrs(uint(nativeEndian.Uint32(b[12:16])), parseKernelInetAddr, b[w.bodyOff:])

--- a/route/sys.go
+++ b/route/sys.go
@@ -41,5 +41,8 @@ func roundup(l int) int {
 type wireFormat struct {
 	extOff  int // offset of header extension
 	bodyOff int // offset of message body
+	idOff   int // offset of ID field, or zero when absent
+	seqOff  int // offset of sequence field, or zero when absent
+	errOff  int // offset of errno field, or zero when absent
 	parse   func(RIBType, []byte) (Message, error)
 }

--- a/route/sys_darwin.go
+++ b/route/sys_darwin.go
@@ -52,7 +52,7 @@ func (m *InterfaceMessage) Sys() []Sys {
 }
 
 func probeRoutingStack() (int, map[int]*wireFormat) {
-	rtm := &wireFormat{extOff: 36, bodyOff: sizeofRtMsghdrDarwin15}
+	rtm := &wireFormat{extOff: 36, bodyOff: sizeofRtMsghdrDarwin15, idOff: 16, seqOff: 20, errOff: 28}
 	rtm.parse = rtm.parseRouteMessage
 	rtm2 := &wireFormat{extOff: 36, bodyOff: sizeofRtMsghdr2Darwin15}
 	rtm2.parse = rtm2.parseRouteMessage

--- a/route/sys_dragonfly.go
+++ b/route/sys_dragonfly.go
@@ -49,7 +49,7 @@ func (m *InterfaceMessage) Sys() []Sys {
 
 func probeRoutingStack() (int, map[int]*wireFormat) {
 	var p uintptr
-	rtm := &wireFormat{extOff: 40, bodyOff: sizeofRtMsghdrDragonFlyBSD4}
+	rtm := &wireFormat{extOff: 40, bodyOff: sizeofRtMsghdrDragonFlyBSD4, idOff: 16, seqOff: 20, errOff: 28}
 	rtm.parse = rtm.parseRouteMessage
 	ifm := &wireFormat{extOff: 16, bodyOff: sizeofIfMsghdrDragonFlyBSD4}
 	ifm.parse = ifm.parseInterfaceMessage

--- a/route/sys_freebsd.go
+++ b/route/sys_freebsd.go
@@ -90,13 +90,13 @@ func probeRoutingStack() (int, map[int]*wireFormat) {
 	}
 	var rtm, ifm, ifam, ifmam, ifanm *wireFormat
 	if compatFreeBSD32 {
-		rtm = &wireFormat{extOff: sizeofRtMsghdrFreeBSD10Emu - sizeofRtMetricsFreeBSD10Emu, bodyOff: sizeofRtMsghdrFreeBSD10Emu}
+		rtm = &wireFormat{extOff: sizeofRtMsghdrFreeBSD10Emu - sizeofRtMetricsFreeBSD10Emu, bodyOff: sizeofRtMsghdrFreeBSD10Emu, idOff: 16, seqOff: 20, errOff: 28}
 		ifm = &wireFormat{extOff: 16}
 		ifam = &wireFormat{extOff: sizeofIfaMsghdrFreeBSD10Emu, bodyOff: sizeofIfaMsghdrFreeBSD10Emu}
 		ifmam = &wireFormat{extOff: sizeofIfmaMsghdrFreeBSD10Emu, bodyOff: sizeofIfmaMsghdrFreeBSD10Emu}
 		ifanm = &wireFormat{extOff: sizeofIfAnnouncemsghdrFreeBSD10Emu, bodyOff: sizeofIfAnnouncemsghdrFreeBSD10Emu}
 	} else {
-		rtm = &wireFormat{extOff: sizeofRtMsghdrFreeBSD10 - sizeofRtMetricsFreeBSD10, bodyOff: sizeofRtMsghdrFreeBSD10}
+		rtm = &wireFormat{extOff: sizeofRtMsghdrFreeBSD10 - sizeofRtMetricsFreeBSD10, bodyOff: sizeofRtMsghdrFreeBSD10, idOff: 16, seqOff: 20, errOff: 28}
 		ifm = &wireFormat{extOff: 16}
 		ifam = &wireFormat{extOff: sizeofIfaMsghdrFreeBSD10, bodyOff: sizeofIfaMsghdrFreeBSD10}
 		ifmam = &wireFormat{extOff: sizeofIfmaMsghdrFreeBSD10, bodyOff: sizeofIfmaMsghdrFreeBSD10}

--- a/route/sys_netbsd.go
+++ b/route/sys_netbsd.go
@@ -45,7 +45,7 @@ func (m *InterfaceMessage) Sys() []Sys {
 }
 
 func probeRoutingStack() (int, map[int]*wireFormat) {
-	rtm := &wireFormat{extOff: 40, bodyOff: sizeofRtMsghdrNetBSD7}
+	rtm := &wireFormat{extOff: 40, bodyOff: sizeofRtMsghdrNetBSD7, idOff: 16, seqOff: 20, errOff: 28}
 	rtm.parse = rtm.parseRouteMessage
 	ifm := &wireFormat{extOff: 16, bodyOff: sizeofIfMsghdrNetBSD7}
 	ifm.parse = ifm.parseInterfaceMessage


### PR DESCRIPTION
On Darwin, NET_RT_DUMP2 returns RTM_GET2 messages backed by rt_msghdr2. That header is not a superset of rt_msghdr: the offsets used by rt_msghdr for rtm_pid, rtm_seq, and rtm_errno are instead rtm_refcnt, rtm_parentflags, and rtm_use in rt_msghdr2.

The current classic parser unconditionally reads those offsets into RouteMessage.ID, RouteMessage.Seq, and RouteMessage.Err. Valid RIB entries with non-zero rtm_use are therefore reported as errors.

Represent pid, seq, and errno offsets in wireFormat and leave them unset for Darwin's rt_msghdr2 format. This fixes the incorrect Err value and avoids exposing rt_msghdr2 ref counts and parent flags through unrelated fields.

The inspected XNU route.h sources, from xnu-2422.1.72 through xnu-12377.101.15, use the same rt_msghdr2 layout and have no rtm_errno field. See bsd/net/route.h in apple-oss-distributions/xnu at those tags.

This change does not add API for rt_msghdr2-specific fields such as rtm_refcnt, rtm_parentflags, rtm_use, or rtm_inits. They need a separate API decision; preserving rtm_use via RouteMessage.Err would keep valid routes looking like failed operations.

Fixes golang/go#70593

Change-Id: I7011355e6b9643e7756557b34518b26c9f3e7749