### PR TITLE
http2, dns/dnsmessage: fix typos in comments and strings

### DIFF
--- a/dns/dnsmessage/message_test.go
+++ b/dns/dnsmessage/message_test.go
@@ -1712,7 +1712,7 @@ func FuzzUnpackPack(f *testing.F) {
 
 		var m2 Message
 		if err := m2.Unpack(msgPacked); err != nil {
-			t.Fatalf("failed to unpack message that was succesfully packed: %v", err)
+			t.Fatalf("failed to unpack message that was successfully packed: %v", err)
 		}
 
 		if !reflect.DeepEqual(m, m2) {

--- a/http2/transport.go
+++ b/http2/transport.go
@@ -763,7 +763,7 @@ func (cc *ClientConn) availableLocked() int {
 	return max(0, int(cc.maxConcurrentStreams)-cc.currentRequestCountLocked())
 }
 
-// tooIdleLocked reports whether this connection has been been sitting idle
+// tooIdleLocked reports whether this connection has been sitting idle
 // for too much wall time.
 func (cc *ClientConn) tooIdleLocked() bool {
 	// The Round(0) strips the monontonic clock reading so the


### PR DESCRIPTION
http2/transport.go: remove duplicate "been" in tooIdleLocked comment
dns/dnsmessage/message_test.go: fix misspelling "succesfully" 
-> "successfully"