### PR TITLE
dns/dnsmessage: add boundary check in unpackSVCBResource

### DIFF
--- a/dns/dnsmessage/svcb.go
+++ b/dns/dnsmessage/svcb.go
@@ -189,6 +189,10 @@ func unpackSVCBResource(msg []byte, off int, length uint16) (SVCBResource, error
 	paramsOff := off
 	bodyEnd := off + int(length)
 
+	if bodyEnd > len(msg) {
+		return SVCBResource{}, errResourceLen
+	}
+
 	var err error
 	if r.Priority, paramsOff, err = unpackUint16(msg, paramsOff); err != nil {
 		return SVCBResource{}, &nestedError{"Priority", err}

--- a/dns/dnsmessage/svcb_test.go
+++ b/dns/dnsmessage/svcb_test.go
@@ -391,3 +391,31 @@ func TestSVCBPackLongValue(t *testing.T) {
 		t.Fatalf(`b.HTTPSResource() = %v; want = "ResourceBody: SVCBResource.Params: value too long (>65535 bytes)"`, err)
 	}
 }
+
+func TestSVCBUnpackOutOfBounds(t *testing.T) {
+	// A minimal DNS message with an SVCB record where the header Length
+	// field (65535) maliciously exceeds the physical bounds of the buffer.
+	msg := []byte{
+		0x00, 0x01, // ID
+		0x00, 0x00, // Flags
+		0x00, 0x00, // QDCount = 0
+		0x00, 0x01, // ANCount = 1
+		0x00, 0x00, // NSCount = 0
+		0x00, 0x00, // ARCount = 0
+		0x00,       // Name: "."
+		0x00, 0x40, // Type: SVCB
+		0x00, 0x01, // Class: INET
+		0x00, 0x00, 0x00, 0x00, // TTL
+		0xff, 0xff, // Length: 65535 (Spoofed)
+		0x00, 0x01, // Priority
+		0x00,       // Target
+		0x00, 0x01, // Param Key
+		0xff, 0xf8, // Param Length
+	}
+
+	var m Message
+	err := m.Unpack(msg)
+	if err == nil {
+		t.Fatal("expected error parsing malformed message, got nil")
+	}
+}


### PR DESCRIPTION
Currently, bodyEnd is calculated using the length parameter from the
resource header without verifying if it exceeds the physical capacity
of the msg buffer. 

If a malformed record provides a length that
exceeds the buffer, it bypasses the first-pass parameter validation
and causes an out-of-bounds slice during the second-pass copy.

Adding a check against len(msg) aligns this function with the boundary
enforcement used throughout the rest of the package.