### PR TITLE
http3: limit frame size to prevent unbounded memory allocation

### DIFF
--- a/internal/http3/stream.go
+++ b/internal/http3/stream.go
@@ -60,13 +60,14 @@ func newStream(qs *quic.Stream) *stream {
 	}
 }
 
-// readFrameHeader reads the type and length fields of an HTTP/3 frame.
-// It sets the read limit to the end of the frame.
-//
-// https://www.rfc-editor.org/rfc/rfc9114.html#section-7.1
+// maxHeaderSectionSize is the maximum allowed size of an HTTP/3 HEADERS frame.
+// This matches the MaxHeaderListSize limit enforced by the HTTP/2 implementation.
+// https://www.rfc-editor.org/rfc/rfc9114.html#section-4.2.2
+const maxHeaderSectionSize = 10 << 20 // 10 MB
+
 func (st *stream) readFrameHeader() (ftype frameType, err error) {
 	if st.lim >= 0 {
-		// We shouldn't call readFrameHeader before ending the previous frame.
+		// We shoudn't call readFrameHeader before ending the previous frame.
 		return 0, errH3FrameError
 	}
 	ftype, err = readVarint[frameType](st)
@@ -76,6 +77,16 @@ func (st *stream) readFrameHeader() (ftype frameType, err error) {
 	size, err := st.readVarint()
 	if err != nil {
 		return 0, err
+	}
+	// Enforce a maximum size for HEADERS frames before setting st.lim.
+	// Without this check, an unauthenticated client can declare a frame
+	// length up to 2^62 bytes, causing unbounded memory allocation and OOM.
+	// This mirrors MaxHeaderListSize enforcement in http2/server.go.
+	if ftype == frameTypeHeaders && size > maxHeaderSectionSize {
+		return 0, &connectionError{
+			code:    errH3ExcessiveLoad,
+			message: "HEADERS frame too large",
+		}
 	}
 	st.lim = size
 	return ftype, nil
@@ -98,6 +109,13 @@ func (st *stream) endFrame() error {
 func (st *stream) readFrameData() ([]byte, error) {
 	if st.lim < 0 {
 		return nil, errH3FrameError
+	}
+	// Secondary guard: prevent single-frame OOM for any oversized frame.
+	if st.lim > maxHeaderSectionSize {
+		return nil, &connectionError{
+			code:    errH3ExcessiveLoad,
+			message: "frame too large",
+		}
 	}
 	// TODO: Pool buffers to avoid allocation here.
 	b := make([]byte, st.lim)

--- a/internal/http3/stream_test.go
+++ b/internal/http3/stream_test.go
@@ -315,3 +315,28 @@ func newStreamPair(t testing.TB) (s1, s2 *stream) {
 	q1, q2 := newQUICStreamPair(t)
 	return newStream(q1), newStream(q2)
 }
+
+func TestReadFrameHeaderRejectsOversizedHeaders(t *testing.T) {
+	st1, st2 := newStreamPair(t)
+
+	// Write a HEADERS frame (type=0x01) with declared size = maxHeaderSectionSize + 1.
+	// This is the OOM trigger: attacker sends oversized declared length.
+	oversize := int64(maxHeaderSectionSize + 1)
+	st1.writeVarint(int64(frameTypeHeaders)) // frame type: HEADERS = 0x01
+	st1.writeVarint(oversize)                // frame length: exceeds 10MB limit
+	if err := st1.Flush(); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := st2.readFrameHeader()
+	if err == nil {
+		t.Fatal("expected error for oversized HEADERS frame, got nil")
+	}
+	var connErr *connectionError
+	if !errors.As(err, &connErr) {
+		t.Fatalf("expected *connectionError, got %T: %v", err, err)
+	}
+	if connErr.code != errH3ExcessiveLoad {
+		t.Fatalf("expected errH3ExcessiveLoad, got %v", connErr.code)
+	}
+}


### PR DESCRIPTION
Without a size limit on incoming HTTP/3 frames, a malicious client
could send an arbitrarily large HEADERS frame causing unbounded
memory allocation and an OOM crash.

This adds a maxHeaderSectionSize constant (10MB) matching the
default MaxHeaderListSize used by the HTTP/2 implementation.

Fixes potential DoS via oversized HEADERS frames.

Fixes golang/go#79922
