### PR TITLE
webdav: support filesystem-backed dead properties

### DIFF
--- a/webdav/file.go
+++ b/webdav/file.go
@@ -45,6 +45,10 @@ type FileSystem interface {
 	Stat(ctx context.Context, name string) (os.FileInfo, error)
 }
 
+type FileSystemProps interface {
+	Props(ctx context.Context, name string) (DeadPropsHolder, error)
+}
+
 // A File is returned by a FileSystem's OpenFile method and can be served by a
 // Handler.
 //
@@ -638,15 +642,35 @@ func moveFiles(ctx context.Context, fs FileSystem, src, dst string, overwrite bo
 	return http.StatusNoContent, nil
 }
 
-func copyProps(dst, src File) error {
-	d, ok := dst.(DeadPropsHolder)
-	if !ok {
+func copyProps(ctx context.Context, fs FileSystem, dstName, srcName string, dst, src File) error {
+	d, hasDstFSProp, err := getProps(ctx, fs, dstName)
+	if err != nil {
+		return err
+	}
+	s, hasSrcFSProp, err := getProps(ctx, fs, srcName)
+	if err != nil {
+		return err
+	}
+
+	if !hasDstFSProp {
+		var ok bool
+		d, ok = dst.(DeadPropsHolder)
+		if !ok {
+			return nil
+		}
+	}
+	if !hasSrcFSProp {
+		var ok bool
+		s, ok = src.(DeadPropsHolder)
+		if !ok {
+			return nil
+		}
+	}
+
+	if d == nil || s == nil {
 		return nil
 	}
-	s, ok := src.(DeadPropsHolder)
-	if !ok {
-		return nil
-	}
+
 	m, err := s.DeadProps()
 	if err != nil {
 		return err
@@ -735,7 +759,7 @@ func copyFiles(ctx context.Context, fs FileSystem, src, dst string, overwrite bo
 
 		}
 		_, copyErr := io.Copy(dstFile, srcFile)
-		propsErr := copyProps(dstFile, srcFile)
+		propsErr := copyProps(ctx, fs, dst, src, dstFile, srcFile)
 		closeErr := dstFile.Close()
 		if copyErr != nil {
 			return http.StatusInternalServerError, copyErr

--- a/webdav/file_test.go
+++ b/webdav/file_test.go
@@ -951,6 +951,103 @@ func TestCopyMoveProps(t *testing.T) {
 	}
 }
 
+func TestCopyPropsWithFileSystemProps(t *testing.T) {
+	fsPropName := xml.Name{Space: "fs", Local: "prop"}
+	fsProp := Property{
+		XMLName:  fsPropName,
+		InnerXML: []byte("from-fs"),
+	}
+	ctx := context.Background()
+	base, err := buildTestFS([]string{"write /src contents"})
+	if err != nil {
+		t.Fatalf("cannot create test filesystem: %v", err)
+	}
+	fs := &testFileSystemProps{
+		FileSystem: base,
+		cacheProps: map[string]map[xml.Name]Property{
+			"/src": {
+				fsPropName: fsProp,
+			},
+			"/dst": nil,
+		},
+	}
+
+	if _, err := copyFiles(ctx, fs, "/src", "/dst", true, infiniteDepth, 0); err != nil {
+		t.Fatalf("copyFiles /src /dst: %v", err)
+	}
+
+	gotDst := fs.cacheProps["/dst"]
+	wantDst := map[xml.Name]Property{
+		fsPropName: fsProp,
+	}
+	if !reflect.DeepEqual(gotDst, wantDst) {
+		t.Fatalf("dst fs props:\ngot  %v\nwant %v", gotDst, wantDst)
+	}
+
+	dstFile, err := base.OpenFile(ctx, "/dst", os.O_RDONLY, 0)
+	if err != nil {
+		t.Fatalf("OpenFile /dst: %v", err)
+	}
+	defer dstFile.Close()
+	fileProps, err := dstFile.(DeadPropsHolder).DeadProps()
+	if err != nil {
+		t.Fatalf("dst file DeadProps: %v", err)
+	}
+	if len(fileProps) != 0 {
+		t.Fatalf("dst file props unexpectedly set: %v", fileProps)
+	}
+}
+
+func TestCopyPropsFallbackToFileDeadProps(t *testing.T) {
+	filePropName := xml.Name{Space: "file", Local: "prop"}
+	fileProp := Property{
+		XMLName:  filePropName,
+		InnerXML: []byte("from-file"),
+	}
+
+	ctx := context.Background()
+	base, err := buildTestFS([]string{"write /src contents"})
+	if err != nil {
+		t.Fatalf("cannot create test filesystem: %v", err)
+	}
+	fs := &testFileSystemProps{
+		FileSystem: base,
+		cacheProps:      map[string]map[xml.Name]Property{},
+	}
+
+	srcFile, err := base.OpenFile(ctx, "/src", os.O_RDWR, 0)
+	if err != nil {
+		t.Fatalf("OpenFile /src: %v", err)
+	}
+	_, err = srcFile.(DeadPropsHolder).Patch([]Proppatch{{Props: []Property{fileProp}}})
+	if err != nil {
+		t.Fatalf("Patch /src: %v", err)
+	}
+	if err := srcFile.Close(); err != nil {
+		t.Fatalf("Close /src: %v", err)
+	}
+
+	if _, err := copyFiles(ctx, fs, "/src", "/dst", true, infiniteDepth, 0); err != nil {
+		t.Fatalf("copyFiles /src /dst: %v", err)
+	}
+
+	dstFile, err := base.OpenFile(ctx, "/dst", os.O_RDONLY, 0)
+	if err != nil {
+		t.Fatalf("OpenFile /dst: %v", err)
+	}
+	defer dstFile.Close()
+	gotProps, err := dstFile.(DeadPropsHolder).DeadProps()
+	if err != nil {
+		t.Fatalf("dst file DeadProps: %v", err)
+	}
+	wantProps := map[xml.Name]Property{
+		filePropName: fileProp,
+	}
+	if !reflect.DeepEqual(gotProps, wantProps) {
+		t.Fatalf("dst file props:\ngot  %v\nwant %v", gotProps, wantProps)
+	}
+}
+
 func TestWalkFS(t *testing.T) {
 	testCases := []struct {
 		desc    string

--- a/webdav/prop.go
+++ b/webdav/prop.go
@@ -161,25 +161,65 @@ var liveProps = map[xml.Name]struct {
 }
 
 // TODO(nigeltao) merge props and allprop?
+func getProps(ctx context.Context, fs FileSystem, name string) (DeadPropsHolder, bool, error) {
+	if propsFS, ok := fs.(FileSystemProps); ok {
+		dph, err := propsFS.Props(ctx, name)
+		if err != nil {
+			return nil, false, err
+		}
+		if dph != nil {
+			return dph, true, nil
+		}
+	}
+	return nil, false, nil
+}
+
+func getDeadPropsHolder(ctx context.Context, fs FileSystem, name string, flag int, needFi bool) (DeadPropsHolder, os.FileInfo, func() error, error) {
+	dph, isFsProp, err := getProps(ctx, fs, name)
+	var fi os.FileInfo
+	if isFsProp {
+		if needFi {
+			fi, err = fs.Stat(ctx, name)
+			if err != nil {
+				return nil, nil, nil, err
+			}
+		}
+		return dph, fi, nil, nil
+	}
+
+	f, err := fs.OpenFile(ctx, name, flag, 0)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	if needFi {
+		fi, err = f.Stat()
+		if err != nil {
+			f.Close()
+			return nil, nil, nil, err
+		}
+	}
+	if dph, ok := f.(DeadPropsHolder); ok {
+		return dph, fi, f.Close, nil
+	}
+	return nil, fi, f.Close, nil
+}
 
 // props returns the status of the properties named pnames for resource name.
 //
 // Each Propstat has a unique status and each property name will only be part
 // of one Propstat element.
 func props(ctx context.Context, fs FileSystem, ls LockSystem, name string, pnames []xml.Name) ([]Propstat, error) {
-	f, err := fs.OpenFile(ctx, name, os.O_RDONLY, 0)
+	dph, fi, closeFunc, err := getDeadPropsHolder(ctx, fs, name, os.O_RDONLY, true)
 	if err != nil {
 		return nil, err
 	}
-	defer f.Close()
-	fi, err := f.Stat()
-	if err != nil {
-		return nil, err
+	if closeFunc != nil {
+		defer closeFunc()
 	}
 	isDir := fi.IsDir()
 
 	var deadProps map[xml.Name]Property
-	if dph, ok := f.(DeadPropsHolder); ok {
+	if dph != nil {
 		deadProps, err = dph.DeadProps()
 		if err != nil {
 			return nil, err
@@ -215,19 +255,17 @@ func props(ctx context.Context, fs FileSystem, ls LockSystem, name string, pname
 
 // propnames returns the property names defined for resource name.
 func propnames(ctx context.Context, fs FileSystem, ls LockSystem, name string) ([]xml.Name, error) {
-	f, err := fs.OpenFile(ctx, name, os.O_RDONLY, 0)
+	dph, fi, closeFunc, err := getDeadPropsHolder(ctx, fs, name, os.O_RDONLY, true)
 	if err != nil {
 		return nil, err
 	}
-	defer f.Close()
-	fi, err := f.Stat()
-	if err != nil {
-		return nil, err
+	if closeFunc != nil {
+		defer closeFunc()
 	}
 	isDir := fi.IsDir()
 
 	var deadProps map[xml.Name]Property
-	if dph, ok := f.(DeadPropsHolder); ok {
+	if dph != nil {
 		deadProps, err = dph.DeadProps()
 		if err != nil {
 			return nil, err
@@ -305,12 +343,15 @@ loop:
 		return makePropstats(pstatForbidden, pstatFailedDep), nil
 	}
 
-	f, err := fs.OpenFile(ctx, name, os.O_RDWR, 0)
+	dph, _, closer, err := getDeadPropsHolder(ctx, fs, name, os.O_RDWR, false)
 	if err != nil {
 		return nil, err
 	}
-	defer f.Close()
-	if dph, ok := f.(DeadPropsHolder); ok {
+	if closer != nil {
+		defer closer()
+	}
+
+	if dph != nil {
 		ret, err := dph.Patch(patches)
 		if err != nil {
 			return nil, err

--- a/webdav/prop_test.go
+++ b/webdav/prop_test.go
@@ -562,6 +562,211 @@ func TestMemPS(t *testing.T) {
 	}
 }
 
+type testDeadPropsHolder struct {
+	props map[xml.Name]Property
+}
+
+func (h *testDeadPropsHolder) DeadProps() (map[xml.Name]Property, error) {
+	if len(h.props) == 0 {
+		return nil, nil
+	}
+	ret := make(map[xml.Name]Property, len(h.props))
+	for k, v := range h.props {
+		ret[k] = v
+	}
+	return ret, nil
+}
+
+func (h *testDeadPropsHolder) Patch(patches []Proppatch) ([]Propstat, error) {
+	pstat := Propstat{Status: http.StatusOK}
+	for _, patch := range patches {
+		for _, p := range patch.Props {
+			pstat.Props = append(pstat.Props, Property{XMLName: p.XMLName})
+			if patch.Remove {
+				delete(h.props, p.XMLName)
+				continue
+			}
+			if h.props == nil {
+				h.props = map[xml.Name]Property{}
+			}
+			h.props[p.XMLName] = p
+		}
+	}
+	return []Propstat{pstat}, nil
+}
+
+type testFileSystemProps struct {
+	FileSystem
+	err        error
+	cacheProps map[string]map[xml.Name]Property
+}
+
+func (fs *testFileSystemProps) Props(ctx context.Context, name string) (DeadPropsHolder, error) {
+	if fs.err != nil {
+		return nil, fs.err
+	}
+	props, ok := fs.cacheProps[name]
+	if !ok {
+		return nil, nil
+	}
+	if props == nil {
+		props = map[xml.Name]Property{}
+		fs.cacheProps[name] = props
+	}
+	return &testDeadPropsHolder{props: props}, nil
+}
+
+func patchTestDeadProps(t *testing.T, fs FileSystem, name string, patches []Proppatch) {
+	t.Helper()
+	f, err := fs.OpenFile(context.Background(), name, os.O_RDWR, 0)
+	if err != nil {
+		t.Fatalf("OpenFile(%q): %v", name, err)
+	}
+	defer f.Close()
+	dph, ok := f.(DeadPropsHolder)
+	if !ok {
+		t.Fatalf("OpenFile(%q) did not return a DeadPropsHolder", name)
+	}
+	if _, err := dph.Patch(patches); err != nil {
+		t.Fatalf("Patch(%q): %v", name, err)
+	}
+}
+
+func TestFileSystemProps(t *testing.T) {
+	fsPropName := xml.Name{Space: "fs", Local: "prop"}
+	fsPropName2 := xml.Name{Space: "fs", Local: "prop2"}
+	filePropName := xml.Name{Space: "file", Local: "prop"}
+	fileProp := Property{
+		XMLName:  filePropName,
+		InnerXML: []byte("from-file"),
+	}
+	fsProp := Property{
+		XMLName:  fsPropName,
+		InnerXML: []byte("from-fs"),
+	}
+	fsProp2 := Property{
+		XMLName:  fsPropName2,
+		InnerXML: []byte("from-fs-2"),
+	}
+
+	base, err := buildTestFS([]string{"touch /file"})
+	if err != nil {
+		t.Fatalf("cannot create test filesystem: %v", err)
+	}
+	patchTestDeadProps(t, base, "/file", []Proppatch{{Props: []Property{fileProp}}})
+	fs := &testFileSystemProps{
+		FileSystem: base,
+		cacheProps: map[string]map[xml.Name]Property{"/file": nil},
+	}
+
+	type propOp struct {
+		name    string
+		patches []Proppatch
+		want    map[xml.Name]Property
+	}
+
+	mls := NewMemLS()
+
+	checkAllProps := func(opName string, want map[xml.Name]Property) {
+		t.Helper()
+		propstats, err := allprop(context.Background(), fs, mls, "/file", nil)
+		if err != nil {
+			t.Fatalf("%s allprop: %v", opName, err)
+		}
+		got := map[xml.Name]Property{}
+		for _, pstat := range propstats {
+			for _, p := range pstat.Props {
+				got[p.XMLName] = p
+			}
+		}
+		for name, prop := range want {
+			gotProp, ok := got[name]
+			if !ok {
+				t.Fatalf("%s missing prop %v in allprop", opName, name)
+			}
+			if !reflect.DeepEqual(gotProp.InnerXML, prop.InnerXML) {
+				t.Fatalf("%s prop %v innerXML = %q, want %q", opName, name, gotProp.InnerXML, prop.InnerXML)
+			}
+		}
+		for _, name := range []xml.Name{fsPropName, fsPropName2} {
+			if _, ok := want[name]; ok {
+				continue
+			}
+			if _, ok := got[name]; ok {
+				t.Fatalf("%s unexpectedly exposed prop %v", opName, name)
+			}
+		}
+		if _, ok := got[filePropName]; ok {
+			t.Fatalf("%s unexpectedly exposed prop %v", opName, filePropName)
+		}
+	}
+
+	checkFileDeadProps := func(opName string) {
+		t.Helper()
+		f, err := base.OpenFile(context.Background(), "/file", os.O_RDONLY, 0)
+		if err != nil {
+			t.Fatalf("%s OpenFile: %v", opName, err)
+		}
+		defer f.Close()
+		fileProps, err := f.(DeadPropsHolder).DeadProps()
+		if err != nil {
+			t.Fatalf("%s file DeadProps: %v", opName, err)
+		}
+		if _, ok := fileProps[fsPropName]; ok {
+			t.Fatalf("%s file dead props unexpectedly contain %v: %v", opName, fsPropName, fileProps)
+		}
+		if _, ok := fileProps[fsPropName2]; ok {
+			t.Fatalf("%s file dead props unexpectedly contain %v: %v", opName, fsPropName2, fileProps)
+		}
+		if _, ok := fileProps[filePropName]; !ok {
+			t.Fatalf("%s file dead props missing original file prop: %v", opName, fileProps)
+		}
+	}
+
+	ops := []propOp{{
+		name: "add 1",
+		patches: []Proppatch{{
+			Props: []Property{fsProp},
+		}},
+	}, {
+		name: "add 2",
+		patches: []Proppatch{{
+			Props: []Property{fsProp2},
+		}},
+	}, {
+		name: "get all",
+		want: map[xml.Name]Property{
+			fsPropName:  fsProp,
+			fsPropName2: fsProp2,
+		},
+	}, {
+		name: "del",
+		patches: []Proppatch{{
+			Remove: true,
+			Props: []Property{{
+				XMLName: fsPropName,
+			}},
+		}},
+	}, {
+		name: "get all after del",
+		want: map[xml.Name]Property{
+			fsPropName2: fsProp2,
+		},
+	}}
+
+	for _, op := range ops {
+		if op.patches != nil {
+			if _, err := patch(context.Background(), fs, NewMemLS(), "/file", op.patches); err != nil {
+				t.Fatalf("%s patch: %v", op.name, err)
+			}
+		}
+		if op.want != nil {
+			checkAllProps(op.name, op.want)
+			checkFileDeadProps(op.name)
+		}
+	}
+}
+
 func cmpXMLName(a, b xml.Name) bool {
 	if a.Space != b.Space {
 		return a.Space < b.Space


### PR DESCRIPTION
Introduce FileSystemProps so a FileSystem can provide dead
property holders directly without forcing prop handling through
OpenFile. The lookup now prefers filesystem-level props, falls
back to file-level DeadPropsHolder when the filesystem does not
provide one, and reuses the same helper path for PROPFIND,
PROPPATCH, and property copying during COPY/MOVE.

The tests cover the intended behavior in two layers: prop
handling exercises add/get-all/delete operations against
filesystem-provided props while confirming file-backed dead
props stay hidden and unmodified, and copy behavior verifies
both filesystem-backed property copying and fallback to
file-backed dead properties when no filesystem props are
available.

Fixes golang/go#80232.