### PR TITLE
html: escape text that would close its containing raw text element

### DIFF
--- a/html/render.go
+++ b/html/render.go
@@ -198,7 +198,19 @@ func render1(w writer, n *Node) error {
 	if childTextNodesAreLiteral(n) {
 		for c := n.FirstChild; c != nil; c = c.NextSibling {
 			if c.Type == TextNode {
-				if _, err := w.WriteString(c.Data); err != nil {
+				// Writing the text literally is only safe while it cannot close
+				// the element that contains it. A text node parsed in raw text
+				// mode never can, because the tokenizer would have ended the
+				// element instead, but a <noscript> parsed with scripting
+				// disabled holds decoded markup, and a programmatically built
+				// tree can hold anything. Escaping in that case keeps the text
+				// inside the element; emitting it literally would let it escape
+				// and be re-parsed as markup.
+				if endsRawText(c.Data, n.Data) {
+					if err := escape(w, c.Data); err != nil {
+						return err
+					}
+				} else if _, err := w.WriteString(c.Data); err != nil {
 					return err
 				}
 			} else {
@@ -265,6 +277,39 @@ func childTextNodesAreLiteral(n *Node) bool {
 	default:
 		return false
 	}
+}
+
+// endsRawText reports whether s contains an end tag for the element named tag,
+// which would terminate that element if s were written out literally. It mirrors
+// the tokenizer's readRawEndTag: the tag name is matched ASCII case-insensitively
+// and must be followed by a tag-name terminator.
+//
+// Two elements are excluded, and neither can reach the case this guards against:
+// <plaintext> has no end tag at all -- it consumes the rest of the input -- and
+// <script> follows the script data escaping rules in readScript, under which an
+// embedded "</script>" does not always close the element, so its text can
+// legitimately contain one and must still be written literally.
+func endsRawText(s, tag string) bool {
+	if tag == "plaintext" || tag == "script" {
+		return false
+	}
+	for i := 0; i+1 < len(s); i++ {
+		if s[i] != '<' || s[i+1] != '/' {
+			continue
+		}
+		j := i + 2
+		if len(s)-j <= len(tag) {
+			return false
+		}
+		if !strings.EqualFold(s[j:j+len(tag)], tag) {
+			continue
+		}
+		switch s[j+len(tag)] {
+		case ' ', '\n', '\r', '\t', '\f', '/', '>':
+			return true
+		}
+	}
+	return false
 }
 
 // writeDoctypeQuoted writes s to w surrounded by quotes. Normally it will use double

--- a/html/render_test.go
+++ b/html/render_test.go
@@ -206,6 +206,71 @@ func TestRenderTextNodes(t *testing.T) {
 	}
 }
 
+// When scripting is disabled the parser descends into <noscript> and decodes
+// character references in its contents, so the resulting text node can hold
+// markup. Rendering it literally would let that markup close the element and be
+// re-parsed as live nodes, which turns inert input into an executing element.
+func TestRenderNoscriptScriptingDisabled(t *testing.T) {
+	for _, tc := range []struct {
+		in   string
+		want string
+	}{
+		{
+			in: `<body><noscript>&lt;/noscript&gt;&lt;img src=x onerror=alert(1)&gt;</noscript>`,
+			want: "<html><head></head><body><noscript>&lt;/noscript&gt;&lt;img src=x onerror=alert(1)&gt;" +
+				"</noscript></body></html>",
+		},
+		{
+			in:   `<table><noscript>&lt;/noscript&gt;&lt;img src=x&gt;</noscript></table>`,
+			want: "<html><head></head><body><noscript>&lt;/noscript&gt;&lt;img src=x&gt;</noscript><table></table></body></html>",
+		},
+		{
+			in:   `<svg><desc><noscript>&lt;/noscript&gt;&lt;img src=x&gt;</noscript>`,
+			want: "<html><head></head><body><svg><desc><noscript>&lt;/noscript&gt;&lt;img src=x&gt;</noscript></desc></svg></body></html>",
+		},
+		{
+			// An end tag that the tokenizer would not have accepted must still be
+			// written literally.
+			in:   `<body><noscript>&lt;/noscriptZ&gt;</noscript>`,
+			want: "<html><head></head><body><noscript></noscriptZ></noscript></body></html>",
+		},
+	} {
+		d, err := ParseWithOptions(strings.NewReader(tc.in), ParseOptionEnableScripting(false))
+		if err != nil {
+			t.Fatal(err)
+		}
+		buf := bytes.NewBuffer(nil)
+		if err := Render(buf, d); err != nil {
+			t.Fatal(err)
+		}
+		if buf.String() != tc.want {
+			t.Errorf("%s: got %q, want %q", tc.in, buf.String(), tc.want)
+			continue
+		}
+
+		// The round trip must not introduce elements that the parsed tree did not
+		// contain.
+		d2, err := ParseWithOptions(bytes.NewReader(buf.Bytes()), ParseOptionEnableScripting(false))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got, want := countElements(d2), countElements(d); got != want {
+			t.Errorf("%s: element count changed across render: got %d, want %d", tc.in, got, want)
+		}
+	}
+}
+
+func countElements(n *Node) int {
+	c := 0
+	if n.Type == ElementNode {
+		c++
+	}
+	for ch := n.FirstChild; ch != nil; ch = ch.NextSibling {
+		c += countElements(ch)
+	}
+	return c
+}
+
 func TestRenderFosteredForeignContent(t *testing.T) {
 	a := `<math><mtext><table><mglyph><style><img src=x onerror=alert(1)>`
 	d, err := Parse(strings.NewReader(a))


### PR DESCRIPTION
childTextNodesAreLiteral reports that the text children of script, style,
xmp, iframe, noembed, noframes, noscript and plaintext are to be written
out literally. That is correct for text produced by the tokenizer in raw
text mode, which cannot contain an end tag for its own element: the
tokenizer would have closed the element rather than produce it.

noscript is different. When a document is parsed with scripting disabled,
the parser descends into noscript and decodes character references in its
contents, so the resulting text node can hold arbitrary markup, including
"</noscript>". Rendering that literally lets the text close the element
and be re-parsed as live nodes:

	in:  <body><noscript>&lt;/noscript&gt;&lt;img src=x&gt;</noscript>
	out: <body><noscript></noscript><img src=x></noscript></body>

The parse tree contains no img element; the rendered output does. Callers
that parse untrusted HTML, decide what is safe by walking the tree, and
re-serialize with Render -- the sequence the package documentation
recommends for security contexts -- emit an element they never approved.

Escape a literal text child when it would otherwise close its containing
element. The predicate mirrors the tokenizer's readRawEndTag: "</" plus
the tag name matched ASCII case-insensitively, followed by a tag-name
terminator. For text produced by the tokenizer this never triggers, so
rendering is unchanged.

plaintext and script are excluded. plaintext has no end tag; it consumes
the rest of the input, so no text can close it. script follows the script
data escaping rules in readScript, under which an embedded "</script>"
does not always close the element, so its text can legitimately contain
one and must still be written literally -- html5lib-tests tests16.dat
case 168 covers this.
