### PR TITLE
http2: fix client GOAWAY to send valid Last-Stream-ID

### DIFF
--- a/http2/transport.go
+++ b/http2/transport.go
@@ -854,7 +854,12 @@ func (cc *ClientConn) sendGoAway() error {
 	cc.mu.Lock()
 	closing := cc.closing
 	cc.closing = true
-	maxStreamID := cc.nextStreamID
+		// Last-Stream-ID must be in the peer's stream-id space: for a client
+	// that's a server-initiated (even) id, or 0. The odd nextStreamID isn't
+	// valid there, so a strict server (nghttp2) rejects the GOAWAY as
+	// PROTOCOL_ERROR. Since the client has no server-initiated streams
+	// (push is off), 0 is correct.
+	maxStreamID := uint32(0)
 	cc.mu.Unlock()
 	if closing {
 		// GOAWAY sent already


### PR DESCRIPTION
Fixes golang/go#80759

## Problem
Client-initiated GOAWAY uses `cc.nextStreamID` (odd) as Last-Stream-ID. 
RFC 9113 §6.8 requires Last-Stream-ID to be in the receiver's stream-id 
space — for a client's GOAWAY, that's server-initiated (even) or 0.
Strict servers (nghttp2, Envoy with nghttp2 codec) reject the frame 
as PROTOCOL_ERROR.

## Fix
Changed `maxStreamID := cc.nextStreamID` to `maxStreamID := uint32(0)` in 
`sendGoAway()`. The client has no server-initiated streams (push is off), 
so 0 is correct and accepted by all servers.

## Testing
- No behavioral change for non-nghttp2 servers (they accept the previous 
  odd value too, but 0 is also valid per spec)
- Fixes the PROTOCOL_ERROR on nghttp2 servers
- Existing tests cover the GOAWAY path