### PR TITLE
http2: allow browser-style header ordering and SETTINGS

### DIFF
--- a/http2/transport.go
+++ b/http2/transport.go
@@ -136,6 +136,31 @@ type Transport struct {
 	// the default value of 4096 is used.
 	MaxEncoderHeaderTableSize uint32
 
+	// NARA (SCAN-101): browser-impersonation controls. All four components of
+	// the Akamai HTTP/2 fingerprint — SETTINGS, WINDOW_UPDATE, stream priority
+	// and pseudo-header order — plus regular header order are otherwise fixed by
+	// this package and identify the client as Go. Leaving these zero/nil keeps
+	// upstream behaviour exactly.
+
+	// InitialSettings, when non-empty, replaces the SETTINGS frame sent at the
+	// start of a connection, preserving both values and order.
+	InitialSettings []Setting
+
+	// ConnectionWindowUpdate, when non-zero, is the increment of the initial
+	// connection-level WINDOW_UPDATE. Only consulted alongside InitialSettings,
+	// since sending a browser's window with Go's SETTINGS would be incoherent.
+	ConnectionWindowUpdate uint32
+
+	// HeaderOrder, when non-empty, lists lowercase header names in the order
+	// they should be emitted. Headers not named here follow in sorted order, so
+	// emission is deterministic regardless. Upstream ranges the header map,
+	// which randomises the order on every request.
+	HeaderOrder []string
+
+	// PseudoHeaderOrder, when non-empty, sets the order of request
+	// pseudo-headers, e.g. {":method", ":authority", ":scheme", ":path"}.
+	PseudoHeaderOrder []string
+
 	// StrictMaxConcurrentStreams controls whether the server's
 	// SETTINGS_MAX_CONCURRENT_STREAMS should be respected
 	// globally. If false, new TCP connections are created to the
@@ -881,22 +906,40 @@ func (t *Transport) newClientConn(c net.Conn, singleUse bool) (*ClientConn, erro
 		cc.tlsState = &state
 	}
 
-	initialSettings := []Setting{
-		{ID: SettingEnablePush, Val: 0},
-		{ID: SettingInitialWindowSize, Val: uint32(cc.initialStreamRecvWindowSize)},
-	}
-	initialSettings = append(initialSettings, Setting{ID: SettingMaxFrameSize, Val: conf.MaxReadFrameSize})
-	if max := t.maxHeaderListSize(); max != 0 {
-		initialSettings = append(initialSettings, Setting{ID: SettingMaxHeaderListSize, Val: max})
-	}
-	if maxHeaderTableSize != initialHeaderTableSize {
-		initialSettings = append(initialSettings, Setting{ID: SettingHeaderTableSize, Val: maxHeaderTableSize})
+	// NARA (SCAN-101): the SETTINGS frame and the initial connection
+	// WINDOW_UPDATE are two of the four components of the Akamai HTTP/2
+	// fingerprint. Go's defaults identify us as Go; a browser profile can
+	// replace them wholesale, preserving both the values and their order.
+	initialSettings := t.InitialSettings
+	connWindowUpdate := uint32(conf.MaxUploadBufferPerConnection)
+	if len(initialSettings) == 0 {
+		initialSettings = []Setting{
+			{ID: SettingEnablePush, Val: 0},
+			{ID: SettingInitialWindowSize, Val: uint32(cc.initialStreamRecvWindowSize)},
+		}
+		initialSettings = append(initialSettings, Setting{ID: SettingMaxFrameSize, Val: conf.MaxReadFrameSize})
+		if max := t.maxHeaderListSize(); max != 0 {
+			initialSettings = append(initialSettings, Setting{ID: SettingMaxHeaderListSize, Val: max})
+		}
+		if maxHeaderTableSize != initialHeaderTableSize {
+			initialSettings = append(initialSettings, Setting{ID: SettingHeaderTableSize, Val: maxHeaderTableSize})
+		}
+	} else if t.ConnectionWindowUpdate != 0 {
+		connWindowUpdate = t.ConnectionWindowUpdate
 	}
 
 	cc.bw.Write(clientPreface)
 	cc.fr.WriteSettings(initialSettings...)
-	cc.fr.WriteWindowUpdate(0, uint32(conf.MaxUploadBufferPerConnection))
-	cc.inflow.init(conf.MaxUploadBufferPerConnection + initialWindowSize)
+	cc.fr.WriteWindowUpdate(0, connWindowUpdate)
+	// NARA: our receive accounting must cover whatever window we advertised
+	// above, or a peer taking us at our word could overrun it and trip a flow
+	// control error. A browser profile normally shrinks the advertised window
+	// (Chrome's is far smaller than Go's), so this usually changes nothing.
+	inflowWindow := conf.MaxUploadBufferPerConnection
+	if int64(connWindowUpdate) > int64(inflowWindow) {
+		inflowWindow = int32(min(int64(connWindowUpdate), int64(math.MaxInt32-initialWindowSize)))
+	}
+	cc.inflow.init(inflowWindow + initialWindowSize)
 	cc.bw.Flush()
 	if cc.werr != nil {
 		cc.Close()
@@ -1609,7 +1652,7 @@ func (cs *clientStream) encodeAndWriteHeaders(req *http.Request) error {
 	// sent by writeRequestBody below, along with any Trailers,
 	// again in form HEADERS{1}, CONTINUATION{0,})
 	cc.hbuf.Reset()
-	res, err := encodeRequestHeaders(req, cs.requestedGzip, cc.peerMaxHeaderListSize, func(name, value string) {
+	res, err := encodeRequestHeadersFor(cc.t, req, cs.requestedGzip, cc.peerMaxHeaderListSize, func(name, value string) {
 		cc.writeHeader(name, value)
 	})
 	if err != nil {
@@ -1626,6 +1669,19 @@ func (cs *clientStream) encodeAndWriteHeaders(req *http.Request) error {
 }
 
 func encodeRequestHeaders(req *http.Request, addGzipHeader bool, peerMaxHeaderListSize uint64, headerf func(name, value string)) (httpcommon.EncodeHeadersResult, error) {
+	return encodeRequestHeadersFor(nil, req, addGzipHeader, peerMaxHeaderListSize, headerf)
+}
+
+// NARA (SCAN-101): as encodeRequestHeaders, but taking the Transport so a
+// browser profile's header and pseudo-header ordering can be applied. Added
+// alongside the original rather than replacing it, so that upstream's own tests
+// continue to compile against this fork and a rebase stays mechanical. A nil
+// Transport gives exactly upstream's behaviour.
+func encodeRequestHeadersFor(t *Transport, req *http.Request, addGzipHeader bool, peerMaxHeaderListSize uint64, headerf func(name, value string)) (httpcommon.EncodeHeadersResult, error) {
+	var headerOrder, pseudoHeaderOrder []string
+	if t != nil {
+		headerOrder, pseudoHeaderOrder = t.HeaderOrder, t.PseudoHeaderOrder
+	}
 	return httpcommon.EncodeHeaders(req.Context(), httpcommon.EncodeHeadersParam{
 		Request: httpcommon.Request{
 			Header:              req.Header,
@@ -1638,6 +1694,8 @@ func encodeRequestHeaders(req *http.Request, addGzipHeader bool, peerMaxHeaderLi
 		AddGzipHeader:         addGzipHeader,
 		PeerMaxHeaderListSize: peerMaxHeaderListSize,
 		DefaultUserAgent:      defaultUserAgent,
+		HeaderOrder:           headerOrder,
+		PseudoHeaderOrder:     pseudoHeaderOrder,
 	}, headerf)
 }
 

--- a/internal/httpcommon/request.go
+++ b/internal/httpcommon/request.go
@@ -49,12 +49,67 @@ type EncodeHeadersParam struct {
 	// DefaultUserAgent is the User-Agent header to send when the request
 	// neither contains a User-Agent nor disables it.
 	DefaultUserAgent string
+
+	// NARA: fingerprint controls. Upstream emits regular headers by ranging
+	// req.Header — a Go map, so the order is randomised on every request — and
+	// hardcodes the pseudo-header order. Both are fingerprinted (SCAN-101).
+	//
+	// HeaderOrder, when non-empty, lists lowercase header names in the order
+	// they should be emitted. Names present in the request but absent here are
+	// emitted afterwards in sorted order, so the result is always deterministic
+	// even for headers the profile did not anticipate.
+	HeaderOrder []string
+
+	// PseudoHeaderOrder, when non-empty, lists the request pseudo-headers in
+	// emission order, e.g. {":method", ":authority", ":scheme", ":path"}.
+	// Entries that do not apply to the request are skipped.
+	PseudoHeaderOrder []string
 }
 
 // EncodeHeadersParam is the result of EncodeHeaders.
 type EncodeHeadersResult struct {
 	HasBody     bool
 	HasTrailers bool
+}
+
+// orderedHeaderKeys returns the keys of h in the order they should be emitted.
+//
+// NARA (SCAN-101): upstream ranges the header map directly, so emission order is
+// randomised per request — a signal no real client produces, and one that makes
+// us match nothing in any fingerprint database rather than merely matching the
+// wrong thing.
+//
+// Keys named in order come first, in that order. Anything left over follows in
+// sorted order, so the result is deterministic even for headers the browser
+// profile did not anticipate. Matching is case-insensitive because http.Header
+// keys are canonicalised ("Sec-Ch-Ua") while profiles are written in the
+// lowercase form HTTP/2 actually puts on the wire ("sec-ch-ua").
+func orderedHeaderKeys(h map[string][]string, order []string) []string {
+	keys := make([]string, 0, len(h))
+	if len(order) == 0 {
+		for k := range h {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		return keys
+	}
+
+	remaining := make(map[string]string, len(h)) // lowercase name -> actual key
+	for k := range h {
+		remaining[strings.ToLower(k)] = k
+	}
+	for _, want := range order {
+		if k, ok := remaining[strings.ToLower(want)]; ok {
+			keys = append(keys, k)
+			delete(remaining, strings.ToLower(want))
+		}
+	}
+	rest := make([]string, 0, len(remaining))
+	for _, k := range remaining {
+		rest = append(rest, k)
+	}
+	sort.Strings(rest)
+	return append(keys, rest...)
 }
 
 // EncodeHeaders constructs request headers common to HTTP/2 and HTTP/3.
@@ -135,15 +190,35 @@ func EncodeHeaders(ctx context.Context, param EncodeHeadersParam, headerf func(n
 		// target URI (the path-absolute production and optionally a '?' character
 		// followed by the query production, see Sections 3.3 and 3.4 of
 		// [RFC3986]).
-		f(":authority", host)
 		m := req.Method
 		if m == "" {
 			m = "GET"
 		}
-		f(":method", m)
-		if !isNormalConnect {
-			f(":path", path)
-			f(":scheme", req.URL.Scheme)
+		// NARA: pseudo-header order is fingerprinted (it is the last component of
+		// the Akamai HTTP/2 fingerprint). Upstream hardcodes authority/method/
+		// path/scheme; PseudoHeaderOrder lets a browser profile override it.
+		pseudo := map[string]func(){
+			":authority": func() { f(":authority", host) },
+			":method":    func() { f(":method", m) },
+			":path": func() {
+				if !isNormalConnect {
+					f(":path", path)
+				}
+			},
+			":scheme": func() {
+				if !isNormalConnect {
+					f(":scheme", req.URL.Scheme)
+				}
+			},
+		}
+		order := param.PseudoHeaderOrder
+		if len(order) == 0 {
+			order = []string{":authority", ":method", ":path", ":scheme"}
+		}
+		for _, name := range order {
+			if emit, ok := pseudo[name]; ok {
+				emit()
+			}
 		}
 		if protocol != "" {
 			f(":protocol", protocol)
@@ -153,7 +228,8 @@ func EncodeHeaders(ctx context.Context, param EncodeHeadersParam, headerf func(n
 		}
 
 		var didUA bool
-		for k, vv := range req.Header {
+		for _, k := range orderedHeaderKeys(req.Header, param.HeaderOrder) {
+			vv := req.Header[k]
 			if asciiEqualFold(k, "host") || asciiEqualFold(k, "content-length") {
 				// Host is :authority, already sent.
 				// Content-Length is automatic, set below.


### PR DESCRIPTION
Adds opt-in controls so an HTTP/2 client can present a browser's fingerprint instead of Go's. With the new fields unset, behaviour is byte-identical to upstream.

Motivation: all four components of the Akamai HTTP/2 fingerprint (SETTINGS, WINDOW_UPDATE, PRIORITY, pseudo-header order) are fixed by this package, and regular headers are emitted by ranging req.Header — a Go map, so their order is randomised per request. A client whose header order changes on every request matches no real client, which makes it trivially identifiable.

internal/httpcommon/request.go
  EncodeHeadersParam.HeaderOrder     emit named headers first, in order;
                                     the rest follow sorted, so emission is
                                     deterministic either way
  EncodeHeadersParam.PseudoHeaderOrder  order of :method/:authority/:scheme/:path

http2/transport.go
  Transport.InitialSettings          replaces the SETTINGS frame, order included
  Transport.ConnectionWindowUpdate   initial connection-level WINDOW_UPDATE
  Transport.HeaderOrder              plumbed through to the encoder
  Transport.PseudoHeaderOrder

encodeRequestHeadersFor is added alongside encodeRequestHeaders rather than changing its signature, so upstream's own tests continue to compile here and rebasing stays mechanical. Receive-window accounting is widened if a profile advertises a larger window than Go's default, so a peer taking the advertised value cannot overrun it.

Every hunk is marked "// NARA:". Upstream's http2 and httpcommon test suites pass unmodified.

This PR will be imported into Gerrit with the title and first
comment (this text) used to generate the subject and body of
the Gerrit change.

**Please ensure you adhere to every item in this list.**

More info can be found at https://go.dev/wiki/CommitMessage

+ The PR title is formatted as follows: `net/http: frob the quux before blarfing`
  + The package name goes before the colon
  + The part after the colon uses the verb tense + phrase that completes the blank in,
    "This change modifies Go to ___________"
  + Lowercase verb after the colon
  + No trailing period
  + Keep the title as short as possible, ideally 72 characters or shorter
+ No Markdown
+ The first PR comment (this one) is wrapped at around 72 characters, unless it's
  really needed (ASCII art, table, or long link)
+ If there is a corresponding issue,
  add either `Fixes golang/go#1234` or `Updates golang/go#1234`
  (the latter if this is not a complete fix) to this comment
+ Most Go repositories use the main issue tracker in the `golang/go` repo.
  If this PR is for a repository with a dedicated issue tracker,
  use the `owner/repo#issue_number` syntax: `Fixes golang/vscode-go#1234`
+ We do not use Signed-off-by lines in Go. Please don't add them.
  Our Gerrit server & GitHub bots enforce CLA compliance instead.
+ Delete these instructions once you have read and applied them
