### PR TITLE
dict: fix unquote panic when backslash is the last character

### DIFF
--- a/dict/dict.go
+++ b/dict/dict.go
@@ -203,6 +203,9 @@ func unquote(s string) string {
 		c := b[r]
 		if c == '\\' {
 			r++
+			if r >= len(b) {
+				break
+			}
 			c = b[r]
 		}
 		b[w] = c

--- a/dict/dict_test.go
+++ b/dict/dict_test.go
@@ -1,0 +1,28 @@
+// Copyright 2026 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package dict
+
+import "testing"
+
+func TestUnquote(t *testing.T) {
+	tests := []struct {
+		in, want string
+	}{
+		{"hello", "hello"},
+		{`hello\ world`, "hello world"},
+		{`hello\\world`, `hello\world`},
+		{`trailing\\`, `trailing\`},
+		{`\\`, `\`},
+		{`\`, ""},
+		{`a\`, "a"},
+		{`\a`, "a"},
+	}
+	for _, tt := range tests {
+		got := unquote(tt.in)
+		if got != tt.want {
+			t.Errorf("unquote(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
The unquote function did not check bounds after advancing past a
backslash, causing an index out of range panic when the backslash
was the final character in the string.

Add a bounds check and break out of the loop when the backslash
has no following character to escape.

Fixes golang/go#259