### PR TITLE
dict: consume dot-body when skipping malformed Define entries

### DIFF
--- a/dict/dict.go
+++ b/dict/dict.go
@@ -124,6 +124,10 @@ func (c *Client) Define(dict, word string) ([]*Defn, error) {
 		a, _ := fields(line)
 		if len(a) < 3 {
 			// skip it, to keep protocol in sync
+			_, err = c.text.ReadDotBytes()
+			if err != nil {
+				return nil, err
+			}
 			i--
 			n--
 			def = def[0:n]

--- a/dict/dict_test.go
+++ b/dict/dict_test.go
@@ -1,0 +1,87 @@
+// Copyright 2010 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package dict
+
+import (
+	"bufio"
+	"net"
+	"net/textproto"
+	"testing"
+)
+
+func TestDefineSkipsMalformedEntry(t *testing.T) {
+	server, client := net.Pipe()
+	defer server.Close()
+	defer client.Close()
+
+	tc := textproto.NewConn(client)
+	c := &Client{text: tc}
+
+	go func() {
+		br := bufio.NewReader(server)
+		// Consume the DEFINE command sent by Cmd.
+		br.ReadString('\n')
+
+		// Send a response with two entries:
+		// - first is malformed (only 1 field, no database/description)
+		// - second is valid
+		resp := "150 2 definitions found\r\n" +
+			"151 bad-entry\r\n" +
+			"should be skipped body\r\n" +
+			".\r\n" +
+			"151 word1 db1 \"Description 1\"\r\n" +
+			"definition text here\r\n" +
+			".\r\n" +
+			"250 ok\r\n"
+		server.Write([]byte(resp))
+	}()
+
+	defs, err := c.Define("*", "test")
+	if err != nil {
+		t.Fatalf("Define failed: %v", err)
+	}
+	if len(defs) != 1 {
+		t.Fatalf("expected 1 definition, got %d", len(defs))
+	}
+	if defs[0].Word != "word1" {
+		t.Fatalf("expected word 'word1', got %q", defs[0].Word)
+	}
+	// ReadDotBytes joins dot-body lines with \n.
+	if string(defs[0].Text) != "definition text here\n" {
+		t.Fatalf("unexpected definition text: %q", string(defs[0].Text))
+	}
+}
+
+func TestDefineAllValid(t *testing.T) {
+	server, client := net.Pipe()
+	defer server.Close()
+	defer client.Close()
+
+	tc := textproto.NewConn(client)
+	c := &Client{text: tc}
+
+	go func() {
+		br := bufio.NewReader(server)
+		br.ReadString('\n')
+
+		resp := "150 2 definitions found\r\n" +
+			"151 word1 db1 \"Description 1\"\r\n" +
+			"text one\r\n" +
+			".\r\n" +
+			"151 word2 db2 \"Description 2\"\r\n" +
+			"text two\r\n" +
+			".\r\n" +
+			"250 ok\r\n"
+		server.Write([]byte(resp))
+	}()
+
+	defs, err := c.Define("*", "test")
+	if err != nil {
+		t.Fatalf("Define failed: %v", err)
+	}
+	if len(defs) != 2 {
+		t.Fatalf("expected 2 definitions, got %d", len(defs))
+	}
+}


### PR DESCRIPTION
When `Define()` encounters a 151 response line with fewer than 3 fields, it skipped the entry but did not call `ReadDotBytes()` to consume the dot-terminated body that follows every 151 response per RFC 2229. The code comment even said "to keep protocol in sync" but the body was never consumed.

This caused the next `ReadCodeLine(151)` to read the unconsumed dot-body instead of the next 151 response line, completely desynchronizing the protocol. Any subsequent entries and the final 250 status line would be misread.

The fix calls `ReadDotBytes()` (with error handling) before `continue` in the skip path to properly consume and discard the body.

A test using `net.Pipe()` + `textproto.NewConn` verifies that a malformed entry followed by a valid entry is handled correctly — the malformed body is consumed and the valid definition is returned.