### PR TITLE
internal/http3: limit the size of decoded QPACK field names and values

### DIFF
--- a/internal/http3/qpack.go
+++ b/internal/http3/qpack.go
@@ -266,6 +266,11 @@ func appendPrefixedInt(b []byte, firstByte byte, prefixLen uint8, i int64) []byt
 // https://www.rfc-editor.org/rfc/rfc9204.html#section-4.1.2
 // https://www.rfc-editor.org/rfc/rfc7541#section-5.2
 
+// maxQPACKStringLen is the maximum length of a field name or value
+// that we are willing to buffer while decoding a field section.
+// HTTP/2's HPACK decoder enforces a similar, configurable limit.
+const maxQPACKStringLen = 1 << 20 // 1 MiB
+
 // readPrefixedString reads an RFC 7541 string from st.
 func (st *stream) readPrefixedString(prefixLen uint8) (firstByte byte, s string, err error) {
 	firstByte, err = st.ReadByte()
@@ -284,6 +289,12 @@ func (st *stream) readPrefixedStringWithByte(firstByte byte, prefixLen uint8) (s
 		return "", errQPACKDecompressionFailed
 	}
 	if st.lim >= 0 && size > st.lim {
+		return "", errQPACKDecompressionFailed
+	}
+	if size > maxQPACKStringLen {
+		// The frame containing this field section may be arbitrarily large,
+		// so the limit above does not bound the size of the buffer we would
+		// allocate below.
 		return "", errQPACKDecompressionFailed
 	}
 

--- a/internal/http3/qpack_test.go
+++ b/internal/http3/qpack_test.go
@@ -153,6 +153,27 @@ func TestPrefixedString(t *testing.T) {
 	}
 }
 
+func TestPrefixedStringTooLong(t *testing.T) {
+	st1, st2 := newStreamPair(t)
+	// A string longer than maxQPACKStringLen must be rejected based on its
+	// length alone, before allocating a buffer or consuming the string data.
+	st1.Write(appendPrefixedInt(nil, 0, 7, maxQPACKStringLen+1))
+	const sentinel = 0xff
+	st1.Write([]byte{sentinel})
+	if err := st1.Flush(); err != nil {
+		t.Fatal(err)
+	}
+	st1.CloseWrite()
+	if b, v, err := st2.readPrefixedString(7); err == nil {
+		t.Fatalf("readPrefixedString(7) = %x, %q, nil; want error", b, v)
+	}
+	// The string data is left unread, indicating that we rejected the string
+	// before attempting to buffer it.
+	if b, err := st2.ReadByte(); err != nil || b != sentinel {
+		t.Errorf("after oversized string, ReadByte() = %x, %v; want %x, nil", b, err, sentinel)
+	}
+}
+
 func TestHuffmanDecodingFailure(t *testing.T) {
 	st1, st2 := newStreamPair(t)
 	st1.Write([]byte{


### PR DESCRIPTION
readPrefixedStringWithByte allocates a buffer for a field name or value
based on the length encoded on the wire, before reading the string data.

The existing check bounds that length by the read limit of the current
frame, but a frame length is itself an unbounded QUIC varint, so a peer
can declare an arbitrarily large field section in a few bytes and cause
a correspondingly large allocation without sending any string data.

Reject strings longer than 1 MiB, as HPACK does for HTTP/2.

Fixes golang/go#78702
