### PR TITLE
http2: count a lost ping exactly once, and never on a failed connection

### DIFF
--- a/http2/export_test.go
+++ b/http2/export_test.go
@@ -14,6 +14,7 @@ import (
 	"net/textproto"
 	"sync"
 	"testing"
+	"time"
 
 	"golang.org/x/net/http2/hpack"
 	"golang.org/x/net/internal/httpcommon"
@@ -113,10 +114,32 @@ func (t *Transport) TestNewClientConn(c net.Conn, singleUse bool, internalStateH
 }
 
 func (t *Transport) TestSetNewClientConnHook(f func(*ClientConn)) {
-	t.transportTestHooks = &transportTestHooks{
-		newclientconn: f,
+	if t.transportTestHooks == nil {
+		t.transportTestHooks = &transportTestHooks{}
 	}
+	t.transportTestHooks.newclientconn = f
 }
+
+// TestSetReadLoopExitedHook installs f to run on a connection's read-loop
+// goroutine after its terminal exit is published and before its cleanup.
+func (t *Transport) TestSetReadLoopExitedHook(f func(*ClientConn)) {
+	if t.transportTestHooks == nil {
+		t.transportTestHooks = &transportTestHooks{}
+	}
+	t.transportTestHooks.readLoopExited = f
+}
+
+// TestSetNewHealthCheckTimerHook installs f to observe each connection's
+// health-check timer as it is created.
+func (t *Transport) TestSetNewHealthCheckTimerHook(f func(*time.Timer)) {
+	if t.transportTestHooks == nil {
+		t.transportTestHooks = &transportTestHooks{}
+	}
+	t.transportTestHooks.newHealthCheckTimer = f
+}
+
+// TestCloseForLostPing invokes the lost-ping close claim directly.
+func (cc *ClientConn) TestCloseForLostPing() { cc.closeForLostPing() }
 
 func (t *Transport) TestTransport() *http.Transport {
 	if t.t1 == nil {

--- a/http2/transport.go
+++ b/http2/transport.go
@@ -77,6 +77,12 @@ type transportInternal struct {
 
 type transportTestHooks struct {
 	newclientconn func(*ClientConn)
+	// readLoopExited, if non-nil, runs on a connection's read-loop goroutine
+	// after the loop publishes its terminal exit and before its cleanup.
+	readLoopExited func(*ClientConn)
+	// newHealthCheckTimer, if non-nil, observes each connection's
+	// health-check timer as it is created.
+	newHealthCheckTimer func(*time.Timer)
 }
 
 func (t *Transport) maxHeaderListSize() uint32 {
@@ -195,6 +201,12 @@ type ClientConn struct {
 	// readLoop goroutine fields:
 	readerDone chan struct{} // closed on error
 	readerErr  error         // set before readerDone is closed
+
+	// readLoopExited is owned by mu and set once the read loop has observed
+	// a terminal connection error, before cleanup publishes closed. Lost-ping
+	// classification consults it so a concurrently failing ping is never
+	// counted after the connection has terminally failed.
+	readLoopExited bool
 
 	idleTimeout time.Duration // or 0 for never
 	idleTimer   *time.Timer
@@ -486,7 +498,7 @@ func (t *Transport) newClientConn(c net.Conn, singleUse bool, internalStateHook 
 		lastActive:                  time.Now(),
 		internalStateHook:           internalStateHook,
 	}
-	if t.transportTestHooks != nil {
+	if t.transportTestHooks != nil && t.transportTestHooks.newclientconn != nil {
 		t.transportTestHooks.newclientconn(cc)
 		c = cc.tconn
 	}
@@ -892,13 +904,29 @@ func (cc *ClientConn) close() error {
 	return nil
 }
 
-// closes the client connection immediately. In-flight requests are interrupted.
+// closeForLostPing closes the client connection if this health check is the
+// one that claims it. The eligibility check and the claim share one critical
+// section: a connection that is already closed, whose read loop has published
+// a terminal failure, or that an overlapping health check already claimed is
+// not a lost ping and is not counted again. In-flight requests on a claimed
+// connection are interrupted.
 func (cc *ClientConn) closeForLostPing() {
 	err := errors.New("http2: client connection lost")
+	cc.mu.Lock()
+	if cc.closed || cc.readLoopExited {
+		cc.mu.Unlock()
+		return
+	}
+	cc.closed = true
+	for _, cs := range cc.streams {
+		cs.abortStreamLocked(err)
+	}
+	cc.cond.Broadcast()
+	cc.mu.Unlock()
 	if f := cc.t.CountError; f != nil {
 		f("conn_close_lost_ping")
 	}
-	cc.closeForError(err)
+	cc.closeConn()
 }
 
 // errRequestCanceled is a copy of net/http's errRequestCanceled because it's not
@@ -1758,6 +1786,12 @@ func (cc *ClientConn) readLoop() {
 	rl := &clientConnReadLoop{cc: cc}
 	defer rl.cleanup()
 	cc.readerErr = rl.run()
+	cc.mu.Lock()
+	cc.readLoopExited = true
+	cc.mu.Unlock()
+	if hooks := cc.t.transportTestHooks; hooks != nil && hooks.readLoopExited != nil {
+		hooks.readLoopExited(cc)
+	}
 	if ce, ok := cc.readerErr.(ConnectionError); ok {
 		cc.wmu.Lock()
 		cc.fr.WriteGoAway(0, ErrCode(ce), nil)
@@ -1873,6 +1907,13 @@ func (rl *clientConnReadLoop) run() error {
 	var t *time.Timer
 	if readIdleTimeout != 0 {
 		t = time.AfterFunc(readIdleTimeout, cc.healthCheck)
+		if hooks := cc.t.transportTestHooks; hooks != nil && hooks.newHealthCheckTimer != nil {
+			hooks.newHealthCheckTimer(t)
+		}
+		// The timer is re-armed below after every ReadFrame return, including
+		// the final erroring one; without a Stop it would outlive the
+		// connection and health-check the closed conn once more.
+		defer t.Stop()
 	}
 	for {
 		f, err := cc.fr.ReadFrame()
@@ -1891,6 +1932,12 @@ func (rl *clientConnReadLoop) run() error {
 			}
 			continue
 		} else if err != nil {
+			// Publish the terminal exit before counting, so a concurrently
+			// failing health-check ping cannot also classify this failure
+			// as a lost ping.
+			cc.mu.Lock()
+			cc.readLoopExited = true
+			cc.mu.Unlock()
 			cc.countReadFrameError(err)
 			return err
 		}

--- a/http2/transport_test.go
+++ b/http2/transport_test.go
@@ -2907,6 +2907,169 @@ func testTransportCloseAfterLostPing(t testing.TB) {
 	}
 }
 
+// A connection close must not surface as a lost ping: the health-check timer
+// used to survive the readLoop's exit and re-ping the dead connection once,
+// counting a spurious conn_close_lost_ping ~ReadIdleTimeout after every close.
+func TestTransportNoLostPingAfterConnClose(t *testing.T) {
+	synctestTest(t, testTransportNoLostPingAfterConnClose)
+}
+func testTransportNoLostPingAfterConnClose(t testing.TB) {
+	var lostPings atomic.Int64
+	var hcTimer atomic.Pointer[time.Timer]
+	tc := newTestClientConn(t, func(tr *Transport) {
+		tr.PingTimeout = 1 * time.Second
+		tr.ReadIdleTimeout = 1 * time.Second
+		tr.CountError = func(errType string) {
+			if errType == "conn_close_lost_ping" {
+				lostPings.Add(1)
+			}
+		}
+		tr.TestSetNewHealthCheckTimerHook(func(tm *time.Timer) {
+			hcTimer.Store(tm)
+		})
+	})
+	tc.greet()
+
+	tc.closeWrite()
+	// The timer must be disarmed at the exit itself, checked before the
+	// instant it would otherwise fire.
+	time.Sleep(1 * time.Millisecond)
+	tm := hcTimer.Load()
+	if tm == nil {
+		t.Fatalf("health-check timer was never created")
+	}
+	if tm.Stop() {
+		t.Errorf("health-check timer still armed after the read loop exited")
+	}
+	time.Sleep(3 * time.Second)
+	if n := lostPings.Load(); n != 0 {
+		t.Errorf("conn_close_lost_ping count = %d after connection close, want 0", n)
+	}
+}
+
+// A genuine lost ping on a live connection is detected and counted exactly
+// once: after the detection closes the connection, waking the read loop's
+// blocked read must not re-arm the health check into a second, phantom
+// count.
+func TestTransportLostPingCountedOnce(t *testing.T) {
+	synctestTest(t, testTransportLostPingCountedOnce)
+}
+func testTransportLostPingCountedOnce(t testing.TB) {
+	var lostPings atomic.Int64
+	tc := newTestClientConn(t, func(tr *Transport) {
+		tr.PingTimeout = 1 * time.Second
+		tr.ReadIdleTimeout = 1 * time.Second
+		tr.CountError = func(errType string) {
+			if errType == "conn_close_lost_ping" {
+				lostPings.Add(1)
+			}
+		}
+	})
+	tc.greet()
+
+	// No frames for ReadIdleTimeout: a health-check ping goes out and is
+	// never answered.
+	time.Sleep(1 * time.Second)
+	tc.wantFrameType(FramePing)
+	// Past the ping deadline, not at it: sleeping to the exact instant races
+	// the health check's own timeout processing under synctest.
+	time.Sleep(1*time.Second + 1*time.Millisecond)
+	if n := lostPings.Load(); n != 1 {
+		t.Fatalf("conn_close_lost_ping count = %d after a lost ping, want 1", n)
+	}
+	// Wake the read loop's blocked read so it observes the teardown; the
+	// exit must not re-arm the health check into a second, phantom count.
+	tc.closeWrite()
+	time.Sleep(3 * time.Second)
+	if n := lostPings.Load(); n != 1 {
+		t.Errorf("conn_close_lost_ping count = %d after the connection closed, want 1", n)
+	}
+}
+
+// A health-check ping that fails after the read loop has observed a terminal
+// connection error must not be classified as a lost ping, even before
+// cleanup marks the connection closed. The read loop is held in that window
+// by the test hook.
+func TestTransportPingRacingReadLoopExitNotLostPing(t *testing.T) {
+	synctestTest(t, testTransportPingRacingReadLoopExitNotLostPing)
+}
+func testTransportPingRacingReadLoopExitNotLostPing(t testing.TB) {
+	var lostPings atomic.Int64
+	release := make(chan struct{})
+	parked := make(chan struct{})
+	var parkOnce sync.Once
+	tc := newTestClientConn(t, func(tr *Transport) {
+		tr.PingTimeout = 1 * time.Second
+		tr.ReadIdleTimeout = 1 * time.Second
+		tr.CountError = func(errType string) {
+			if errType == "conn_close_lost_ping" {
+				lostPings.Add(1)
+			}
+		}
+		tr.TestSetReadLoopExitedHook(func(cc *ClientConn) {
+			parkOnce.Do(func() { close(parked) })
+			<-release
+		})
+	})
+	tc.greet()
+
+	// The health check fires and its PING is in flight, unanswered.
+	time.Sleep(1*time.Second + 1*time.Millisecond)
+	tc.wantFrameType(FramePing)
+
+	// The peer breaks the connection; the read loop observes the terminal
+	// error and parks in the hook, before cleanup marks the conn closed.
+	tc.closeWrite()
+	<-parked
+
+	// The in-flight ping now times out inside that window.
+	time.Sleep(1 * time.Second)
+	if n := lostPings.Load(); n != 0 {
+		t.Errorf("conn_close_lost_ping count = %d for a ping racing the read loop's exit, want 0", n)
+	}
+
+	close(release)
+	time.Sleep(2 * time.Second)
+	if n := lostPings.Load(); n != 0 {
+		t.Errorf("conn_close_lost_ping count = %d after teardown, want 0", n)
+	}
+}
+
+// Overlapping health checks must produce exactly one lost-ping count: the
+// eligibility check and the close claim share one critical section, so a
+// second claimant always observes the first claim.
+func TestTransportLostPingClaimedOnce(t *testing.T) {
+	synctestTest(t, testTransportLostPingClaimedOnce)
+}
+func testTransportLostPingClaimedOnce(t testing.TB) {
+	var lostPings atomic.Int64
+	tc := newTestClientConn(t, func(tr *Transport) {
+		tr.CountError = func(errType string) {
+			if errType == "conn_close_lost_ping" {
+				lostPings.Add(1)
+			}
+		}
+	})
+	tc.greet()
+
+	const claimants = 8
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for range claimants {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			tc.cc.TestCloseForLostPing()
+		}()
+	}
+	close(start)
+	wg.Wait()
+	if n := lostPings.Load(); n != 1 {
+		t.Errorf("conn_close_lost_ping count = %d from %d overlapping claims, want 1", n, claimants)
+	}
+}
+
 func TestTransportPingWriteBlocks(t *testing.T) {
 	ts := newTestServer(t,
 		func(w http.ResponseWriter, r *http.Request) {},


### PR DESCRIPTION
The health-check timer is re-armed after every ReadFrame return,
including the final erroring one, and no close path stops it: one
ReadIdleTimeout after every connection close a post-mortem health
check pings the dead connection, fails immediately, and reports a
spurious CountError("conn_close_lost_ping"). A genuinely lost ping is
counted twice: the real detection, then the post-close echo.

CL 198040 shipped the health check with the timer stopped when the
read loop exits; CL 572378, an unrelated test-infrastructure
conversion, dropped the stop with no behavioral rationale (v0.22.0
has it, v0.23.0 does not). Restore the stop, publish the read loop's
terminal exit under cc.mu before the failure is counted, and make
lost-ping classification a single-claim close: the eligibility check
and the claim share one critical section in closeForLostPing, so
overlapping health checks, or a ping racing the read loop's terminal
exit, can never produce a second count. The CountError callback runs
outside the lock. A ping that fails on a connection that is live at
claim time is still counted and still closes the connection,
preserving the write-blocked-ping detection of CL 354389.

This fixes the legacy transport, used on Go versions before 1.27 and
with the http2legacy build tag (go build -tags=http2legacy). The
default Go 1.27 path uses net/http's copy of this code, which has the
same defect and is fixed separately; that change closes the issue.

Updates golang/go#80920
