### PR TITLE
x/net/idna: fix checking hyphen at 3rd and 4th character

### DIFF
--- a/idna/idna.go
+++ b/idna/idna.go
@@ -787,7 +787,7 @@ func (p *Profile) validateLabel(s string, labelCode string) (err error) {
 		return nil
 	}
 	if p.checkHyphens {
-		if len(s) > 4 && s[2] == '-' && s[3] == '-' {
+		if hasHyphenAt3rdAnd4th(s) {
 			return labelError{s, "V2"}
 		}
 		if s[0] == '-' || s[len(s)-1] == '-' {
@@ -851,6 +851,17 @@ func (p *Profile) validateLabel(s string, labelCode string) (err error) {
 	}
 
 	return nil
+}
+
+func hasHyphenAt3rdAnd4th(s string) bool {
+	_, size := utf8.DecodeRuneInString(s)
+	s = s[size:]
+	if len(s) == 0 {
+		return false
+	}
+	_, size = utf8.DecodeRuneInString(s)
+	s = s[size:]
+	return len(s) >= 2 && s[0] == '-' && s[1] == '-'
 }
 
 func ascii(s string) bool {

--- a/idna/idna_test.go
+++ b/idna/idna_test.go
@@ -65,6 +65,7 @@ func TestIDNASeparators(t *testing.T) {
 				{"example\u3002jp", "example.jp", false},
 				{"東京\uFF0Ejp", "xn--1lqs71d.jp", false},
 				{"大阪\uFF61jp", "xn--pssu33l.jp", false},
+				{"大阪--府.jp", "", true},
 			},
 		},
 		{


### PR DESCRIPTION
Check hyphen restrictions according to Section 4.2.3.1 of
RFC 5891.

4.2.3.1.  Hyphen Restrictions
The Unicode string MUST NOT contain "--" (two consecutive
hyphens) in the third and fourth character positions and
MUST NOT start or end with a "-" (hyphen).

https://www.rfc-editor.org/info/rfc5891/#section-4.2.3.1

Fixes golang/go#81026
