### PR TITLE
webdav/internal/xml: make Decoder.Skip iterative

### DIFF
--- a/webdav/internal/xml/read.go
+++ b/webdav/internal/xml/read.go
@@ -666,11 +666,12 @@ Loop:
 
 // Skip reads tokens until it has consumed the end element
 // matching the most recent start element already consumed.
-// It recurs if it encounters a start element, so it can be used to
-// skip nested structures.
+// It tracks nesting depth iteratively so it can be used to
+// skip nested structures of arbitrary depth.
 // It returns nil if it finds an end element matching the start
 // element; otherwise it returns an error describing the problem.
 func (d *Decoder) Skip() error {
+	depth := 0
 	for {
 		tok, err := d.Token()
 		if err != nil {
@@ -678,11 +679,12 @@ func (d *Decoder) Skip() error {
 		}
 		switch tok.(type) {
 		case StartElement:
-			if err := d.Skip(); err != nil {
-				return err
-			}
+			depth++
 		case EndElement:
-			return nil
+			if depth == 0 {
+				return nil
+			}
+			depth--
 		}
 	}
 }

--- a/webdav/internal/xml/read_test.go
+++ b/webdav/internal/xml/read_test.go
@@ -742,3 +742,29 @@ func TestUnmarshalIntoInterface(t *testing.T) {
 		t.Errorf("failed to unmarshal into interface, have %q want %q", have, want)
 	}
 }
+
+// Deeply nested unknown elements must be skipped without exhausting the
+// goroutine stack. Mirrors the encoding/xml fix for golang.org/issue/53614.
+func TestSkipDeepNesting(t *testing.T) {
+	depth := 100000
+	var b strings.Builder
+	b.WriteString("<result><value>7</value><unknown>")
+	for i := 0; i < depth; i++ {
+		b.WriteString("<a>")
+	}
+	for i := 0; i < depth; i++ {
+		b.WriteString("</a>")
+	}
+	b.WriteString("</unknown></result>")
+
+	v := struct {
+		XMLName Name  `xml:"result"`
+		Value   int64 `xml:"value"`
+	}{}
+	if err := Unmarshal([]byte(b.String()), &v); err != nil {
+		t.Fatalf("unmarshal of deeply nested document failed: %v", err)
+	}
+	if v.Value != 7 {
+		t.Errorf("sibling field not parsed, have %d want 7", v.Value)
+	}
+}


### PR DESCRIPTION
Fixes the webdav half of golang/go#81181.

`Decoder.Skip()` in the internal encoding/xml fork recurses once per nested element, so deeply nested XML exhausts the goroutine stack. The standard library fixed the identical bug in Go 1.19 by making Skip iterative (golang/go#53614, CVE-2022-28131); this fork was frozen from the stdlib in 2015 and never picked the fix up.

An unauthenticated LOCK, PROPFIND, or PROPPATCH body containing an element that matches no struct field reaches Skip via readLockInfo/readPropfind/readProppatch. 20M nested elements (a ~140 MB body; the handler enforces no body-size limit) reliably produces:

```
runtime: goroutine stack exceeds 1000000000-byte limit
fatal error: stack overflow
```

which no caller can recover from — the process dies.

Track nesting depth with a counter instead of recursing, mirroring the stdlib fix, plus a regression test unmarshalling a 100k-deep document through the fork's public Unmarshal. All `webdav` and `webdav/internal/xml` tests pass; the 20M-depth PoC that previously killed the process now returns cleanly.